### PR TITLE
Workstation makes better use of vertical screen real estate

### DIFF
--- a/gui/src/main/java/io/xj/gui/controllers/MainMenuController.java
+++ b/gui/src/main/java/io/xj/gui/controllers/MainMenuController.java
@@ -4,6 +4,8 @@ package io.xj.gui.controllers;
 
 import io.xj.gui.services.ThemeService;
 import javafx.application.HostServices;
+import javafx.beans.property.BooleanProperty;
+import javafx.beans.property.SimpleBooleanProperty;
 import javafx.fxml.FXML;
 import javafx.scene.control.CheckMenuItem;
 import javafx.scene.control.MenuBar;
@@ -17,6 +19,8 @@ import org.springframework.stereotype.Service;
 @Service
 public class MainMenuController extends MenuBar implements ReadyAfterBootController {
   Logger LOG = LoggerFactory.getLogger(MainMenuController.class);
+  final BooleanProperty logsVisible = new SimpleBooleanProperty(false);
+  final BooleanProperty logsTailing = new SimpleBooleanProperty(true);
   final HostServices hostServices;
   final ConfigurableApplicationContext ac;
   final String launchGuideUrl;
@@ -26,6 +30,12 @@ public class MainMenuController extends MenuBar implements ReadyAfterBootControl
 
   @FXML
   protected CheckMenuItem checkboxDarkTheme;
+
+  @FXML
+  protected CheckMenuItem checkboxShowLogs;
+
+  @FXML
+  protected CheckMenuItem checkboxTailLogs;
 
   public MainMenuController(
     @SuppressWarnings("SpringJavaInjectionPointsAutowiringInspection") HostServices hostServices,
@@ -46,6 +56,9 @@ public class MainMenuController extends MenuBar implements ReadyAfterBootControl
   @Override
   public void onStageReady() {
     themeService.isDarkThemeProperty().bindBidirectional(checkboxDarkTheme.selectedProperty());
+    logsVisible.bindBidirectional(checkboxShowLogs.selectedProperty());
+    logsTailing.bindBidirectional(checkboxTailLogs.selectedProperty());
+    checkboxTailLogs.disableProperty().bind(logsVisible.not());
   }
 
   @Override
@@ -76,4 +89,11 @@ public class MainMenuController extends MenuBar implements ReadyAfterBootControl
     modalLabConnectionController.launchModal();
   }
 
+  public BooleanProperty logsTailingProperty() {
+    return logsTailing;
+  }
+
+  public BooleanProperty logsVisibleProperty() {
+    return logsVisible;
+  }
 }

--- a/gui/src/main/java/io/xj/gui/controllers/MainPaneTopController.java
+++ b/gui/src/main/java/io/xj/gui/controllers/MainPaneTopController.java
@@ -36,6 +36,7 @@ public class MainPaneTopController extends VBox implements ReadyAfterBootControl
   final static String BUTTON_TEXT_STOP = "Stop";
   final static String BUTTON_TEXT_RESET = "Reset";
   final FabricationService fabricationService;
+  final ModalLabConnectionController modalLabConnectionController;
   final LabService labService;
   final BooleanProperty configVisible = new SimpleBooleanProperty(false);
 
@@ -93,11 +94,18 @@ public class MainPaneTopController extends VBox implements ReadyAfterBootControl
   @FXML
   TextField fieldOutputFrameRate;
 
+  @FXML
+  public Button buttonLab;
+
+  @FXML
+  public Label labelLabStatus;
+
   public MainPaneTopController(
     FabricationService fabricationService,
-    LabService labService
+    ModalLabConnectionController modalLabConnectionController, LabService labService
   ) {
     this.fabricationService = fabricationService;
+    this.modalLabConnectionController = modalLabConnectionController;
     this.labService = labService;
   }
 
@@ -159,6 +167,8 @@ public class MainPaneTopController extends VBox implements ReadyAfterBootControl
 
     toggleShowConfig.setSelected(configVisible.get());
 
+    labelLabStatus.textProperty().bind(labService.statusProperty().map(Enum::toString));
+
     updateConfigVisibility();
   }
 
@@ -192,6 +202,11 @@ public class MainPaneTopController extends VBox implements ReadyAfterBootControl
   public void toggleShowConfig(ActionEvent ignored) {
     configVisible.set(toggleShowConfig.isSelected());
     updateConfigVisibility();
+  }
+
+  @FXML
+  public void handleButtonLabPressed(ActionEvent ignored) {
+    modalLabConnectionController.launchModal();
   }
 
   void updateConfigVisibility() {

--- a/gui/src/main/resources/styles/dark-theme.css
+++ b/gui/src/main/resources/styles/dark-theme.css
@@ -83,7 +83,7 @@
   -fx-table-cell-border-color: transparent;
 }
 
-.bottom-pane-status-container, .top-pane-status-container {
+.top-pane-status-container {
   -fx-background-color: #494949;
 }
 

--- a/gui/src/main/resources/styles/default-theme.css
+++ b/gui/src/main/resources/styles/default-theme.css
@@ -36,10 +36,6 @@
   -fx-text-fill: red;
 }
 
-.bottom-pane-status-container {
-  -fx-background-color: #c0c0c0;
-}
-
 .top-pane-status-container {
   -fx-background-color: #c9c9c9;
 }

--- a/gui/src/main/resources/views/main-menu.fxml
+++ b/gui/src/main/resources/views/main-menu.fxml
@@ -13,6 +13,9 @@
   </Menu>
   <Menu mnemonicParsing="false" text="View">
     <CheckMenuItem fx:id="checkboxDarkTheme" mnemonicParsing="false" selected="true" text="Dark Theme"/>
+    <SeparatorMenuItem mnemonicParsing="false"/>
+    <CheckMenuItem fx:id="checkboxShowLogs" mnemonicParsing="false" text="Show Logs"/>
+    <CheckMenuItem fx:id="checkboxTailLogs" mnemonicParsing="false" selected="true" text="Logs Auto-scroll" disable="true"/>
   </Menu>
   <Menu mnemonicParsing="false" text="Help">
     <MenuItem mnemonicParsing="false" onAction="#onLaunchUserGuide" text="User Guide"/>

--- a/gui/src/main/resources/views/main-pane-bottom.fxml
+++ b/gui/src/main/resources/views/main-pane-bottom.fxml
@@ -2,42 +2,9 @@
 
 <!-- Copyright (c) XJ Music Inc. (https://xjmusic.com) All Rights Reserved. -->
 
-<?import javafx.geometry.Insets?>
-<?import javafx.scene.control.Label?>
 <?import javafx.scene.control.ListView?>
-<?import javafx.scene.control.ToggleButton?>
-<?import javafx.scene.layout.*?>
-<?import javafx.scene.control.Button?>
+<?import javafx.scene.layout.VBox?>
 <VBox xmlns="http://javafx.com/javafx/20.0.1" xmlns:fx="http://javafx.com/fxml/1"
       fx:controller="io.xj.gui.controllers.MainPaneBottomController">
-  <HBox alignment="CENTER" styleClass="bottom-pane-status-container"
-        xmlns:fx="http://javafx.com/fxml">
-    <HBox.hgrow>
-      <Priority fx:constant="ALWAYS"/>
-    </HBox.hgrow>
-    <padding>
-      <Insets bottom="6" left="9" right="9" top="6"/>
-    </padding>
-    <HBox alignment="CENTER_LEFT" spacing="9"
-          xmlns:fx="http://javafx.com/fxml">
-      <HBox.hgrow>
-        <Priority fx:constant="ALWAYS"/>
-      </HBox.hgrow>
-      <Button fx:id="buttonLab" onAction="#handleButtonLabPressed" text="Lab" />
-      <Label fx:id="labelLabStatus" text="Initializing"/>
-    </HBox>
-    <HBox alignment="CENTER_RIGHT" spacing="10"
-          xmlns:fx="http://javafx.com/fxml">
-      <HBox.hgrow>
-        <Priority fx:constant="ALWAYS"/>
-      </HBox.hgrow>
-
-      <!-- Logs Auto-Scroll Toggle Switch -->
-      <ToggleButton fx:id="toggleTailLogs" text="Auto-Scroll"/>
-
-      <!-- Show Logs Toggle Switch -->
-      <ToggleButton fx:id="toggleShowLogs" text="Logs"/>
-    </HBox>
-  </HBox>
   <ListView fx:id="logListView" prefHeight="400.0" prefWidth="769.0" styleClass="log-viewer"/>
 </VBox>

--- a/gui/src/main/resources/views/main-pane-top.fxml
+++ b/gui/src/main/resources/views/main-pane-top.fxml
@@ -194,7 +194,13 @@
         <Priority fx:constant="ALWAYS"/>
       </HBox.hgrow>
 
-      <!-- Future: right side of top pane status bar -->
+      <!-- Lab Connection Status Text -->
+      <Label fx:id="labelLabStatus" text="Initializing"/>
+
+      <!-- Lab Button -->
+      <Button fx:id="buttonLab" onAction="#handleButtonLabPressed" text="Lab" />
+
+
 
     </HBox>
   </HBox>


### PR DESCRIPTION
- Move the "Logs" and "Follow logs" toggle switches to View menu items
- Move the Lab button and connection status to the top pane bar
- When logs are not shown, the bottom pane should be invisible

https://www.pivotaltracker.com/story/show/186045980