### PR TITLE
Lab menu

### DIFF
--- a/gui/src/main/java/io/xj/gui/WorkstationGuiFxApplication.java
+++ b/gui/src/main/java/io/xj/gui/WorkstationGuiFxApplication.java
@@ -7,7 +7,6 @@ import jakarta.annotation.Nullable;
 import javafx.application.Application;
 import javafx.application.HostServices;
 import javafx.application.Platform;
-import javafx.scene.text.Font;
 import javafx.stage.Stage;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/gui/src/main/java/io/xj/gui/controllers/MainMenuController.java
+++ b/gui/src/main/java/io/xj/gui/controllers/MainMenuController.java
@@ -2,8 +2,9 @@
 
 package io.xj.gui.controllers;
 
+import io.xj.gui.services.GuideService;
+import io.xj.gui.services.LabService;
 import io.xj.gui.services.ThemeService;
-import javafx.application.HostServices;
 import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.SimpleBooleanProperty;
 import javafx.fxml.FXML;
@@ -11,7 +12,6 @@ import javafx.scene.control.CheckMenuItem;
 import javafx.scene.control.MenuBar;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.SpringApplication;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.stereotype.Service;
@@ -21,12 +21,12 @@ public class MainMenuController extends MenuBar implements ReadyAfterBootControl
   Logger LOG = LoggerFactory.getLogger(MainMenuController.class);
   final BooleanProperty logsVisible = new SimpleBooleanProperty(false);
   final BooleanProperty logsTailing = new SimpleBooleanProperty(true);
-  final HostServices hostServices;
   final ConfigurableApplicationContext ac;
-  final String launchGuideUrl;
   final ThemeService themeService;
+  final GuideService guideService;
+  final LabService labService;
   final ModalAboutController modalAboutController;
-  final ModalLabConnectionController modalLabConnectionController;
+  final ModalLabAuthenticationController modalLabAuthenticationController;
 
   @FXML
   protected CheckMenuItem checkboxDarkTheme;
@@ -38,19 +38,19 @@ public class MainMenuController extends MenuBar implements ReadyAfterBootControl
   protected CheckMenuItem checkboxTailLogs;
 
   public MainMenuController(
-    @SuppressWarnings("SpringJavaInjectionPointsAutowiringInspection") HostServices hostServices,
-    @Value("${gui.launch.guide.url}") String launchGuideUrl,
     ConfigurableApplicationContext ac,
     ModalAboutController modalAboutController,
-    ModalLabConnectionController modalLabConnectionController,
-    ThemeService themeService
+    ModalLabAuthenticationController modalLabAuthenticationController,
+    ThemeService themeService,
+    GuideService guideService,
+    LabService labService
   ) {
     this.ac = ac;
-    this.hostServices = hostServices;
-    this.launchGuideUrl = launchGuideUrl;
     this.modalAboutController = modalAboutController;
-    this.modalLabConnectionController = modalLabConnectionController;
+    this.modalLabAuthenticationController = modalLabAuthenticationController;
     this.themeService = themeService;
+    this.guideService = guideService;
+    this.labService = labService;
   }
 
   @Override
@@ -75,8 +75,7 @@ public class MainMenuController extends MenuBar implements ReadyAfterBootControl
 
   @FXML
   protected void onLaunchUserGuide() {
-    LOG.info("Will launch user guide");
-    hostServices.showDocument(launchGuideUrl);
+    guideService.launchGuideInBrowser();
   }
 
   @FXML
@@ -85,8 +84,13 @@ public class MainMenuController extends MenuBar implements ReadyAfterBootControl
   }
 
   @FXML
-  protected void onConnectToLab() {
-    modalLabConnectionController.launchModal();
+  protected void handleLabAuthentication() {
+    modalLabAuthenticationController.launchModal();
+  }
+
+  @FXML
+  protected void handleLabOpenInBrowser() {
+    labService.launchInBrowser();
   }
 
   public BooleanProperty logsTailingProperty() {

--- a/gui/src/main/java/io/xj/gui/controllers/MainPaneTopController.java
+++ b/gui/src/main/java/io/xj/gui/controllers/MainPaneTopController.java
@@ -36,7 +36,7 @@ public class MainPaneTopController extends VBox implements ReadyAfterBootControl
   final static String BUTTON_TEXT_STOP = "Stop";
   final static String BUTTON_TEXT_RESET = "Reset";
   final FabricationService fabricationService;
-  final ModalLabConnectionController modalLabConnectionController;
+  final ModalLabAuthenticationController modalLabAuthenticationController;
   final LabService labService;
   final BooleanProperty configVisible = new SimpleBooleanProperty(false);
 
@@ -105,10 +105,11 @@ public class MainPaneTopController extends VBox implements ReadyAfterBootControl
 
   public MainPaneTopController(
     FabricationService fabricationService,
-    ModalLabConnectionController modalLabConnectionController, LabService labService
+    ModalLabAuthenticationController modalLabAuthenticationController,
+    LabService labService
   ) {
     this.fabricationService = fabricationService;
-    this.modalLabConnectionController = modalLabConnectionController;
+    this.modalLabAuthenticationController = modalLabAuthenticationController;
     this.labService = labService;
   }
 
@@ -210,7 +211,11 @@ public class MainPaneTopController extends VBox implements ReadyAfterBootControl
 
   @FXML
   public void handleButtonLabPressed(ActionEvent ignored) {
-    modalLabConnectionController.launchModal();
+    if (labService.isAuthenticated()) {
+      labService.launchInBrowser();
+    } else {
+      modalLabAuthenticationController.launchModal();
+    }
   }
 
   void updateConfigVisibility() {

--- a/gui/src/main/java/io/xj/gui/controllers/MainTimelineController.java
+++ b/gui/src/main/java/io/xj/gui/controllers/MainTimelineController.java
@@ -197,14 +197,14 @@ public class MainTimelineController extends ScrollPane implements ReadyAfterBoot
    Called frequently to update the sync (playback position indicator).
    */
   void updateSync() {
-    var m0 = segments.isEmpty() ? 0 : segments.get(0).getBeginAtChainMicros();
+    var m0 = segments.stream().findFirst().map(Segment::getBeginAtChainMicros).orElse(0L);
     var m1Past = fabricationService.getWorkFactory().getShippedToChainMicros().orElse(m0);
     var m2Ship = fabricationService.getWorkFactory().getShipTargetChainMicros().orElse(m1Past);
-    var m3Craft = fabricationService.getWorkFactory().getDubbedToChainMicros().orElse(m2Ship);
-    var m4Dub = fabricationService.getWorkFactory().getCraftedToChainMicros().orElse(m3Craft);
+    var m3Dub = fabricationService.getWorkFactory().getDubbedToChainMicros().orElse(m2Ship);
+    var m4Craft = fabricationService.getWorkFactory().getCraftedToChainMicros().orElse(m3Dub);
     timelineRegion1Past.setWidth((m1Past - m0) / microsPerPixel.get());
     timelineRegion2Ship.setWidth((m2Ship - m1Past) / microsPerPixel.get());
-    timelineRegion3Dub.setWidth((m3Craft - m2Ship) / microsPerPixel.get());
-    timelineRegion4Craft.setWidth((m4Dub - m3Craft) / microsPerPixel.get());
+    timelineRegion3Dub.setWidth((m3Dub - m2Ship) / microsPerPixel.get());
+    timelineRegion4Craft.setWidth((m4Craft - m3Dub) / microsPerPixel.get());
   }
 }

--- a/gui/src/main/java/io/xj/gui/controllers/ModalAboutController.java
+++ b/gui/src/main/java/io/xj/gui/controllers/ModalAboutController.java
@@ -5,7 +5,6 @@ package io.xj.gui.controllers;
 import io.xj.gui.services.LabService;
 import io.xj.gui.services.ThemeService;
 import io.xj.gui.services.VersionService;
-import javafx.application.HostServices;
 import javafx.fxml.FXML;
 import javafx.scene.control.Button;
 import javafx.scene.control.Label;
@@ -19,7 +18,6 @@ import org.springframework.stereotype.Service;
 public class ModalAboutController extends ReadyAfterBootModalController {
   static final String ABOUT_WINDOW_NAME = "About";
   final ConfigurableApplicationContext ac;
-  final HostServices hostServices;
   final Resource modalAboutFxml;
   final LabService labService;
   final ThemeService themeService;
@@ -33,7 +31,6 @@ public class ModalAboutController extends ReadyAfterBootModalController {
 
 
   public ModalAboutController(
-    @SuppressWarnings("SpringJavaInjectionPointsAutowiringInspection") HostServices hostServices,
     @Value("classpath:/views/modal-about.fxml") Resource modalAboutFxml,
     ConfigurableApplicationContext ac,
     LabService labService,
@@ -41,7 +38,6 @@ public class ModalAboutController extends ReadyAfterBootModalController {
     VersionService versionService
   ) {
     this.ac = ac;
-    this.hostServices = hostServices;
     this.modalAboutFxml = modalAboutFxml;
     this.labService = labService;
     this.themeService = themeService;

--- a/gui/src/main/java/io/xj/gui/controllers/ModalLabAuthenticationController.java
+++ b/gui/src/main/java/io/xj/gui/controllers/ModalLabAuthenticationController.java
@@ -6,7 +6,6 @@ import io.xj.gui.services.LabService;
 import io.xj.gui.services.LabStatus;
 import io.xj.gui.services.ThemeService;
 import io.xj.hub.tables.pojos.User;
-import javafx.application.HostServices;
 import javafx.beans.binding.Bindings;
 import javafx.fxml.FXML;
 import javafx.scene.control.Button;
@@ -27,20 +26,19 @@ import java.util.List;
 import java.util.Objects;
 
 @Service
-public class ModalLabConnectionController extends ReadyAfterBootModalController {
+public class ModalLabAuthenticationController extends ReadyAfterBootModalController {
   static final List<LabStatus> BUTTON_CONNECT_ACTIVE_IN_LAB_STATES = Arrays.asList(
     LabStatus.Authenticated,
     LabStatus.Unauthorized,
     LabStatus.Failed,
     LabStatus.Offline
   );
-  static final String CONNECT_TO_LAB_WINDOW_NAME = "Connect to Lab";
+  static final String CONNECT_TO_LAB_WINDOW_NAME = "Lab Authentication";
   static final String BUTTON_DISCONNECT_TEXT = "Disconnect";
   static final String BUTTON_CONNECT_TEXT = "Connect";
   private static final Integer USER_AVATAR_SIZE = 120;
   final ConfigurableApplicationContext ac;
-  final HostServices hostServices;
-  final Resource modalLabConnectionFxml;
+  final Resource modalLabAuthenticationFxml;
   final LabService labService;
   final ThemeService themeService;
 
@@ -68,16 +66,14 @@ public class ModalLabConnectionController extends ReadyAfterBootModalController 
   @FXML
   Text textUserEmail;
 
-  public ModalLabConnectionController(
-    @SuppressWarnings("SpringJavaInjectionPointsAutowiringInspection") HostServices hostServices,
-    @Value("classpath:/views/modal-lab-connection.fxml") Resource modalLabConnectionFxml,
+  public ModalLabAuthenticationController(
+    @Value("classpath:/views/modal-lab-authentication.fxml") Resource modalLabAuthenticationFxml,
     ConfigurableApplicationContext ac,
     LabService labService,
     ThemeService themeService
   ) {
     this.ac = ac;
-    this.hostServices = hostServices;
-    this.modalLabConnectionFxml = modalLabConnectionFxml;
+    this.modalLabAuthenticationFxml = modalLabAuthenticationFxml;
     this.labService = labService;
     this.themeService = themeService;
   }
@@ -133,7 +129,7 @@ public class ModalLabConnectionController extends ReadyAfterBootModalController 
 
   @FXML
   void handleLaunchLabPreferences() {
-    hostServices.showDocument(labService.baseUrlProperty().get() + "preferences");
+    labService.launchPreferencesInBrowser();
   }
 
   @FXML
@@ -147,6 +143,6 @@ public class ModalLabConnectionController extends ReadyAfterBootModalController 
 
   @Override
   void launchModal() {
-    doLaunchModal(ac, themeService, modalLabConnectionFxml, CONNECT_TO_LAB_WINDOW_NAME);
+    doLaunchModal(ac, themeService, modalLabAuthenticationFxml, CONNECT_TO_LAB_WINDOW_NAME);
   }
 }

--- a/gui/src/main/java/io/xj/gui/services/GuideService.java
+++ b/gui/src/main/java/io/xj/gui/services/GuideService.java
@@ -1,0 +1,8 @@
+package io.xj.gui.services;
+
+public interface GuideService {
+  /**
+   Launch the guide in a browser
+   */
+  void launchGuideInBrowser();
+}

--- a/gui/src/main/java/io/xj/gui/services/GuideServiceImpl.java
+++ b/gui/src/main/java/io/xj/gui/services/GuideServiceImpl.java
@@ -1,0 +1,26 @@
+// Copyright (c) XJ Music Inc. (https://xjmusic.com) All Rights Reserved.
+
+package io.xj.gui.services;
+
+import javafx.application.HostServices;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+@Service
+public class GuideServiceImpl implements GuideService {
+  final HostServices hostServices;
+  final String launchGuideUrl;
+
+  public GuideServiceImpl(
+    @SuppressWarnings("SpringJavaInjectionPointsAutowiringInspection") HostServices hostServices,
+    @Value("${gui.launch.guide.url}") String launchGuideUrl
+  ) {
+    this.hostServices = hostServices;
+    this.launchGuideUrl = launchGuideUrl;
+  }
+
+  @Override
+  public void launchGuideInBrowser() {
+    hostServices.showDocument(launchGuideUrl);
+  }
+}

--- a/gui/src/main/java/io/xj/gui/services/LabService.java
+++ b/gui/src/main/java/io/xj/gui/services/LabService.java
@@ -3,12 +3,10 @@ package io.xj.gui.services;
 import io.xj.hub.tables.pojos.User;
 import javafx.beans.property.ObjectProperty;
 import javafx.beans.property.StringProperty;
-import javafx.scene.Node;
 import org.springframework.http.HttpMethod;
 import reactor.core.publisher.Mono;
 
 import java.net.URI;
-import java.util.UUID;
 
 public interface LabService {
   void connect();
@@ -46,4 +44,21 @@ public interface LabService {
    @return RUL for given path
    */
   String computeUrl(String path);
+
+  /**
+   Get the URL for a path in the app
+
+   @return UUID for the lab
+   */
+  boolean isAuthenticated();
+
+  /**
+   Launch the lab preferences window in a browser
+   */
+  void launchPreferencesInBrowser();
+
+  /**
+    Launch the lab in a browser
+   */
+  void launchInBrowser();
 }

--- a/gui/src/main/java/io/xj/gui/services/LabServiceImpl.java
+++ b/gui/src/main/java/io/xj/gui/services/LabServiceImpl.java
@@ -3,6 +3,7 @@
 package io.xj.gui.services;
 
 import io.xj.hub.tables.pojos.User;
+import javafx.application.HostServices;
 import javafx.application.Platform;
 import javafx.beans.property.ObjectProperty;
 import javafx.beans.property.SimpleObjectProperty;
@@ -22,6 +23,7 @@ import java.util.regex.Pattern;
 
 @Service
 public class LabServiceImpl implements LabService {
+  private final HostServices hostServices;
   Logger LOG = LoggerFactory.getLogger(LabServiceImpl.class);
   final WebClient webClient;
   final ObjectProperty<LabStatus> status = new SimpleObjectProperty<>(LabStatus.Offline);
@@ -32,8 +34,10 @@ public class LabServiceImpl implements LabService {
   final ObjectProperty<User> authenticatedUser = new SimpleObjectProperty<>();
 
   public LabServiceImpl(
+    @SuppressWarnings("SpringJavaInjectionPointsAutowiringInspection") HostServices hostServices,
     @Value("${lab.base.url}") String defaultLabBaseUrl
   ) {
+    this.hostServices = hostServices;
     this.baseUrl.set(defaultLabBaseUrl);
     this.webClient = WebClient.builder().build();
     baseUrl.addListener((observable, oldValue, newValue) -> {
@@ -121,5 +125,20 @@ public class LabServiceImpl implements LabService {
   @Override
   public String computeUrl(String path) {
     return String.format("%s%s", baseUrl.get(), rgxStripLeadingSlash.matcher(path).replaceAll(""));
+  }
+
+  @Override
+  public boolean isAuthenticated() {
+    return Objects.equals(status.get(), LabStatus.Authenticated);
+  }
+
+  @Override
+  public void launchPreferencesInBrowser() {
+    hostServices.showDocument(baseUrl.get() + "preferences");
+  }
+
+  @Override
+  public void launchInBrowser() {
+    hostServices.showDocument(baseUrl.get());
   }
 }

--- a/gui/src/main/resources/styles/dark-theme.css
+++ b/gui/src/main/resources/styles/dark-theme.css
@@ -16,8 +16,12 @@
   -fx-border-color: transparent;
 }
 
-.menu-item:hover, .menu-button:hover {
+.menu-item:hover, .menu-button:hover, .menu-button:focused, .menu-item:focused {
   -fx-background-color: #474747;
+}
+
+.check-menu-item {
+  -fx-focused-mark-color: lightgray;
 }
 
 .label {

--- a/gui/src/main/resources/views/main-menu.fxml
+++ b/gui/src/main/resources/views/main-menu.fxml
@@ -6,21 +6,24 @@
 <?import javafx.scene.layout.VBox?>
 <MenuBar VBox.vgrow="NEVER" xmlns="http://javafx.com/javafx/20.0.1"
          xmlns:fx="http://javafx.com/fxml/1" fx:controller="io.xj.gui.controllers.MainMenuController">
-  <Menu mnemonicParsing="false" text="Workstation">
-    <MenuItem mnemonicParsing="false" onAction="#onConnectToLab" text="Connect to Lab"/>
-    <SeparatorMenuItem mnemonicParsing="false"/>
-    <MenuItem mnemonicParsing="false" onAction="#onQuit" text="Exit"/>
+  <Menu text="_Workstation">
+    <MenuItem onAction="#onQuit" text="E_xit"/>
   </Menu>
-  <Menu mnemonicParsing="false" text="View">
-    <CheckMenuItem fx:id="checkboxDarkTheme" mnemonicParsing="false" selected="true" text="Dark Theme"/>
+  <Menu text="_Lab">
+    <MenuItem onAction="#handleLabAuthentication" text="_Authentication"/>
     <SeparatorMenuItem mnemonicParsing="false"/>
-    <CheckMenuItem fx:id="checkboxShowLogs" mnemonicParsing="false" text="Show Logs"/>
-    <CheckMenuItem fx:id="checkboxTailLogs" mnemonicParsing="false" selected="true" text="Logs Auto-scroll" disable="true"/>
+    <MenuItem onAction="#handleLabOpenInBrowser" text="_Open in Browser"/>
   </Menu>
-  <Menu mnemonicParsing="false" text="Help">
-    <MenuItem mnemonicParsing="false" onAction="#onLaunchUserGuide" text="User Guide"/>
+  <Menu text="_View">
+    <CheckMenuItem fx:id="checkboxDarkTheme" selected="true" text="_Dark Theme"/>
     <SeparatorMenuItem mnemonicParsing="false"/>
-    <MenuItem mnemonicParsing="false" onAction="#onPressAbout" text="About"/>
+    <CheckMenuItem fx:id="checkboxShowLogs" text="Show _Logs"/>
+    <CheckMenuItem fx:id="checkboxTailLogs" selected="true" text="Logs Auto-_scroll" disable="true"/>
+  </Menu>
+  <Menu text="_Help">
+    <MenuItem onAction="#onLaunchUserGuide" text="User _Guide"/>
+    <SeparatorMenuItem mnemonicParsing="false"/>
+    <MenuItem onAction="#onPressAbout" text="_About"/>
   </Menu>
 </MenuBar>
 

--- a/gui/src/main/resources/views/main-pane-top.fxml
+++ b/gui/src/main/resources/views/main-pane-top.fxml
@@ -181,8 +181,6 @@
       <!-- Lab Button -->
       <Button fx:id="buttonLab" onAction="#handleButtonLabPressed" text="Lab" />
 
-
-
     </HBox>
   </HBox>
 </VBox>

--- a/gui/src/main/resources/views/modal-lab-authentication.fxml
+++ b/gui/src/main/resources/views/modal-lab-authentication.fxml
@@ -9,7 +9,7 @@
 <?import javafx.scene.text.Font?>
 <?import javafx.scene.text.Text?>
 <VBox spacing="10" xmlns="http://javafx.com/javafx/20.0.1"
-      xmlns:fx="http://javafx.com/fxml/1" fx:controller="io.xj.gui.controllers.ModalLabConnectionController">
+      xmlns:fx="http://javafx.com/fxml/1" fx:controller="io.xj.gui.controllers.ModalLabAuthenticationController">
   <padding>
     <Insets bottom="15" left="15" right="15" top="15"/> <!-- Padding values -->
   </padding>
@@ -23,7 +23,7 @@
     <Pane prefHeight="100.0" prefWidth="15.0"/>
     <TextField fx:id="fieldLabUrl" prefHeight="25.0" prefWidth="275.0"/>
     <Pane layoutX="187.0" layoutY="10.0" prefHeight="100.0" prefWidth="15.0"/>
-    <Button onAction="#handleLaunchLabPreferences" text="Get Access Token"/>
+    <Button onAction="#handleLaunchLabPreferences" text="Get _Access Token"/>
   </HBox>
   <HBox alignment="CENTER_LEFT" prefHeight="41.0" prefWidth="640.0">
     <opaqueInsets>
@@ -43,7 +43,7 @@
            text="Status" textAlignment="RIGHT">
     </Label>
     <Pane prefHeight="100.0" prefWidth="15.0"/>
-    <Button fx:id="buttonConnect" onAction="#handleConnect" text="Connect"/>
+    <Button fx:id="buttonConnect" onAction="#handleConnect" text="_Connect"/>
   </HBox>
   <Pane prefHeight="7.0" prefWidth="640.0"/>
   <Separator prefWidth="200.0"/>
@@ -67,6 +67,6 @@
       </Text>
     </VBox>
     <Pane layoutX="192.0" layoutY="10.0" prefHeight="50.0" prefWidth="17.0"/>
-    <Button fx:id="buttonClose" onAction="#handleClose" prefHeight="25.0" prefWidth="56.0" text="OK"/>
+    <Button fx:id="buttonClose" onAction="#handleClose" prefHeight="25.0" prefWidth="56.0" text="_OK"/>
   </HBox>
 </VBox>

--- a/gui/src/test/java/io/xj/gui/services/GuideServiceImplTest.java
+++ b/gui/src/test/java/io/xj/gui/services/GuideServiceImplTest.java
@@ -1,0 +1,34 @@
+// Copyright (c) XJ Music Inc. (https://xjmusic.com) All Rights Reserved.
+
+package io.xj.gui.services;
+
+import javafx.application.HostServices;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class GuideServiceImplTest {
+  GuideService subject;
+
+  @Mock
+  HostServices hostServices;
+
+  @BeforeEach
+  void setUp() {
+    subject = new GuideServiceImpl(hostServices, "https://guide.test.xj.io/");
+  }
+
+  @Test
+  void launchGuideInBrowser() {
+    subject.launchGuideInBrowser();
+
+    verify(hostServices, times(1)).showDocument(eq("https://guide.test.xj.io/"));
+  }
+}

--- a/gui/src/test/java/io/xj/gui/services/LabServiceImplTest.java
+++ b/gui/src/test/java/io/xj/gui/services/LabServiceImplTest.java
@@ -2,17 +2,25 @@
 
 package io.xj.gui.services;
 
+import javafx.application.HostServices;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+@ExtendWith(MockitoExtension.class)
 public class LabServiceImplTest {
   LabService subject;
 
+  @Mock
+  HostServices hostServices;
+
   @BeforeEach
   public void setUp() {
-    subject = new LabServiceImpl("https://lab.test.xj.io/");
+    subject = new LabServiceImpl(hostServices, "https://lab.test.xj.io/");
   }
 
   @Test


### PR DESCRIPTION
Adds a new "Lab" item to the main menu, and moves all lab related functionality there (out of the Workstation menu)

- Remove "Connect to Lab" from the Workstation menu
- Lab ➔ Authentication menu option to open the lab connection modal
- Lab ➔ Open in Browser is the first open in the menu, which simply opens the lab for the user to browse content.
- After authenticating to the Lab, the "Lab" button in the top pane status bar has the behavior of Lab ➔ Open

Workstation has a Lab menu
https://www.pivotaltracker.com/story/show/186048020