### PR TITLE
Fix timeline status algorithm

### DIFF
--- a/gui/src/main/resources/application.properties
+++ b/gui/src/main/resources/application.properties
@@ -6,10 +6,7 @@ gui.launch.guide.url=https://guide.xj.io/
 gui.logs.refresh.seconds=1
 gui.theme.dark=styles/dark-theme.css
 gui.theme.default=styles/default-theme.css
-
-# todo revert this whole file
-gui.timeline.max.segments=9
-
+gui.timeline.max.segments=40
 gui.timeline.refresh.millis=618
 gui.timeline.segment.spacing.horizontal=4
 gui.timeline.segment.width.min=320


### PR DESCRIPTION
Workstation timeline status color bar should not run past end of visible segments when we exceed maximum visible segments
https://www.pivotaltracker.com/story/show/186076761