### PR TITLE
Keyboard shortcuts on MacOS

### DIFF
--- a/gui/src/main/java/io/xj/gui/controllers/MainMenuController.java
+++ b/gui/src/main/java/io/xj/gui/controllers/MainMenuController.java
@@ -13,6 +13,7 @@ import javafx.fxml.FXML;
 import javafx.scene.control.CheckMenuItem;
 import javafx.scene.control.MenuBar;
 import javafx.scene.control.MenuItem;
+import javafx.scene.input.KeyCombination;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.SpringApplication;
@@ -79,7 +80,29 @@ public class MainMenuController extends MenuBar implements ReadyAfterBootControl
     checkboxTailLogs.disableProperty().bind(logsVisible.not());
     itemOpenFabricationSettings.disableProperty().bind(fabricationService.isStatusActive());
     itemFabricationMainAction.textProperty().bind(fabricationService.mainActionButtonTextProperty().map((s) -> String.format("_%s", s)));
+    itemFabricationMainAction.setAccelerator(computeMainActionButtonAccelerator());
     checkboxFabricationFollow.selectedProperty().bindBidirectional(fabricationService.followPlaybackProperty());
+    checkboxFabricationFollow.setAccelerator(computeFabricationFollowButtonAccelerator());
+  }
+
+  /**
+   Compute the accelerator for the main action button.
+   Depending on the platform, it will be either SHORTCUT+SPACE or SHORTCUT+B (on Mac because of conflict).
+
+   @return the accelerator
+   */
+  private KeyCombination computeMainActionButtonAccelerator() {
+    return KeyCombination.valueOf("SHORTCUT+" + (System.getProperty("os.name").toLowerCase().contains("mac") ? "B" : "SPACE"));
+  }
+
+  /**
+   Compute the accelerator for the fabricator follow toggle button.
+   Depending on the platform, it will be either SHORTCUT+ALT+SPACE or SHORTCUT+ALT+B (on Mac because of conflict).
+
+   @return the accelerator
+   */
+  private KeyCombination computeFabricationFollowButtonAccelerator() {
+    return KeyCombination.valueOf("SHORTCUT+ALT+" + (System.getProperty("os.name").toLowerCase().contains("mac") ? "B" : "SPACE"));
   }
 
   @Override

--- a/gui/src/main/resources/views/main-menu.fxml
+++ b/gui/src/main/resources/views/main-menu.fxml
@@ -8,16 +8,8 @@
 <MenuBar VBox.vgrow="NEVER" xmlns="http://javafx.com/javafx/20.0.1"
          xmlns:fx="http://javafx.com/fxml/1" fx:controller="io.xj.gui.controllers.MainMenuController">
   <Menu text="_Fabrication">
-    <MenuItem fx:id="itemFabricationMainAction" onAction="#handleFabricationMainAction" text="_Start">
-      <accelerator>
-        <KeyCodeCombination code="SPACE" alt="UP" control="UP" meta="UP" shift="UP" shortcut="DOWN"/>
-      </accelerator>
-    </MenuItem>
-    <CheckMenuItem fx:id="checkboxFabricationFollow" text="_Follow">
-      <accelerator>
-        <KeyCodeCombination code="SPACE" alt="DOWN" control="UP" meta="UP" shift="UP" shortcut="DOWN"/>
-      </accelerator>
-    </CheckMenuItem>
+    <MenuItem fx:id="itemFabricationMainAction" onAction="#handleFabricationMainAction" text="_Start"/>
+    <CheckMenuItem fx:id="checkboxFabricationFollow" text="_Follow" />
     <SeparatorMenuItem mnemonicParsing="false"/>
     <MenuItem fx:id="itemOpenFabricationSettings" onAction="#handleOpenFabricationSettings" text="S_ettings">
       <accelerator>


### PR DESCRIPTION
- Compute the accelerator for the main action button depending on the platform, it will be either SHORTCUT+SPACE or SHORTCUT+B (on Mac because of conflict).
- Compute the accelerator for the fabricator follow toggle button depending on the platform, it will be either SHORTCUT+ALT+SPACE or SHORTCUT+ALT+B (on Mac because of conflict).

https://www.pivotaltracker.com/story/show/186066853