### PR TITLE
File output advance file number only after non-empty file

### DIFF
--- a/lib/src/main/java/io/xj/lib/mixer/AudioFileWriter.java
+++ b/lib/src/main/java/io/xj/lib/mixer/AudioFileWriter.java
@@ -25,8 +25,10 @@ public interface AudioFileWriter {
 
   /**
    Close the writer and release resources
+
+   @return true if the output file is non-empty
    */
-  void finish() throws IOException;
+  boolean finish() throws IOException;
 
   /**
    @return true if the writer is currently writing

--- a/lib/src/main/java/io/xj/lib/mixer/AudioFileWriterImpl.java
+++ b/lib/src/main/java/io/xj/lib/mixer/AudioFileWriterImpl.java
@@ -78,7 +78,7 @@ public class AudioFileWriterImpl implements AudioFileWriter {
   }
 
   @Override
-  public void finish() {
+  public boolean finish() {
     if (fileState.get() != FileState.WRITING) {
       throw new IllegalStateException("Stream is not open");
     }
@@ -87,7 +87,7 @@ public class AudioFileWriterImpl implements AudioFileWriter {
       tempFile.close();
       if (tempFileByteCount.get() == 0) {
         LOG.warn("Will not write zero-byte {}", outputPath.get());
-        return;
+        return false;
       }
 
       File outputFile = new File(outputPath.get());
@@ -97,8 +97,11 @@ public class AudioFileWriterImpl implements AudioFileWriter {
       AudioSystem.write(ais, AudioFileFormat.Type.WAVE, outputFile);
       this.fileState.set(FileState.DONE);
       LOG.info("Did write {} bytes of PCM data to output WAV container {}", tempFileByteCount.get(), outputPath.get());
+      return true;
+
     } catch (IOException e) {
       LOG.error("Failed to close output file stream!", e);
+      return true;
     }
   }
 


### PR DESCRIPTION
Workstation should never generate empty .WAV containers when writing gapless album https://www.pivotaltracker.com/story/show/185578514