### PR TITLE
Fix timeline view limits

### DIFF
--- a/gui/src/main/java/io/xj/gui/controllers/MainTimelineController.java
+++ b/gui/src/main/java/io/xj/gui/controllers/MainTimelineController.java
@@ -123,6 +123,8 @@ public class MainTimelineController extends ScrollPane implements ReadyAfterBoot
     segmentListView.setSpacing(segmentHorizontalSpacing);
     segmentListView.setPadding(new Insets(0, segmentMinWidth * 3, 0, segmentHorizontalSpacing));
 
+    segmentListView.paddingProperty().bind(scrollPane.widthProperty().map(width -> new Insets(0, width.doubleValue(), 0, segmentHorizontalSpacing)));
+
     scrollPane.hbarPolicyProperty().bind(fabricationService.followPlaybackProperty().map(followPlayback -> followPlayback ? ScrollPane.ScrollBarPolicy.NEVER : ScrollPane.ScrollBarPolicy.AS_NEEDED));
 
     demoContainer.visibleProperty().bind(fabricationService.isStatusStandby());
@@ -183,17 +185,19 @@ public class MainTimelineController extends ScrollPane implements ReadyAfterBoot
    Called to reset the timeline (segment list).
    */
   private void resetTimeline() {
-    ds.clear();
-    scrollPane.setHvalue(0);
-    segmentListView.getChildren().clear();
-    timelineRegion1Past.setWidth(0);
-    timelineRegion2Ship.setWidth(ACTIVE_SHIP_REGION_WIDTH);
-    timelineRegion3Dub.setWidth(0);
-    timelineRegion4Craft.setWidth(0);
     Platform.runLater(() -> {
-      segmentListView.layout();
-      scrollPane.layout();
-      segmentPositionRow.layout();
+      ds.clear();
+      scrollPane.setHvalue(0);
+      segmentListView.getChildren().clear();
+      timelineRegion1Past.setWidth(0);
+      timelineRegion2Ship.setWidth(ACTIVE_SHIP_REGION_WIDTH);
+      timelineRegion3Dub.setWidth(0);
+      timelineRegion4Craft.setWidth(0);
+      Platform.runLater(() -> {
+        segmentListView.layout();
+        scrollPane.layout();
+        segmentPositionRow.layout();
+      });
     });
   }
 


### PR DESCRIPTION
- Timeline shows at least the minimum segment width on the left side (past) to prevent a (minimum width) segment from disappearing off the left side before it's played. We'll revisit this enhancement for segments of a longer width and make the content inside the segment slide to the right as the segment slides off-screen to the left.
- Timeline has at least the screen width of padding on the right side (to prevent the auto-scroll from getting stuck when there wasn't enough space on the right to scroll through)
 
Workstation timeline follow should always keep the entirety of the now playing segment in view https://www.pivotaltracker.com/story/show/186209115

- Use Platform.runLater() for both the first and (nested) second step of a reset

Workstation timeline should visually reset on fabrication reset
https://www.pivotaltracker.com/story/show/186397191