### PR TITLE
Workstation has meme selection in manual mode based on taxonomy

### DIFF
--- a/gui/src/main/java/io/xj/gui/services/FabricationService.java
+++ b/gui/src/main/java/io/xj/gui/services/FabricationService.java
@@ -27,6 +27,7 @@ import javafx.beans.property.StringProperty;
 import javafx.beans.value.ObservableBooleanValue;
 import javafx.beans.value.ObservableDoubleValue;
 import javafx.beans.value.ObservableValue;
+import javafx.collections.ObservableList;
 import javafx.scene.Node;
 
 import java.util.Collection;
@@ -111,6 +112,10 @@ public interface FabricationService {
 
   BooleanProperty followPlaybackProperty();
 
+  ObservableList<String> overrideMemesProperty();
+
+  ObjectProperty<UUID> overrideMacroProgramIdProperty();
+
   ObservableDoubleValue progressProperty();
 
   ObservableBooleanValue isStatusActive();
@@ -180,12 +185,18 @@ public interface FabricationService {
   void cancel();
 
   /**
-   Manually go to a specific macro program
+   Manually go to a specific macro program, and force until reset
    https://www.pivotaltracker.com/story/show/186003440
 
    @param macroProgram the macro program to go to
    */
-  void gotoMacroProgram(Program macroProgram);
+  void doOverrideMacro(Program macroProgram);
+
+  /**
+   Reset the macro program override
+   https://www.pivotaltracker.com/story/show/186003440
+   */
+  void resetOverrideMacro();
 
   /**
    Get all meme taxonomies in the source template
@@ -193,8 +204,16 @@ public interface FabricationService {
   Optional<MemeTaxonomy> getMemeTaxonomy();
 
   /**
-   Manually go to a specific taxonomy category meme
-   https://www.pivotaltracker.com/story/show/186714075@param memes     the meme
+   Manually go to a specific taxonomy category meme, and force until reset
+   https://www.pivotaltracker.com/story/show/186714075
+
+   @param memes specific (assumed allowably) set of taxonomy category memes
    */
-  void gotoTaxonomyCategoryMemes(Collection<String> memes);
+  void doOverrideMemes(Collection<String> memes);
+
+  /**
+   Reset the taxonomy category memes
+   https://www.pivotaltracker.com/story/show/186714075
+   */
+  void resetOverrideMemes();
 }

--- a/gui/src/main/resources/styles/default-theme.css
+++ b/gui/src/main/resources/styles/default-theme.css
@@ -176,25 +176,21 @@
   -fx-cursor: hand;
 }
 
-.macro-selection-container {
+.selection-container {
   -fx-padding: 10 10 10 10;
 }
 
-.macro-selection-container .button {
+.selection-container .button {
   -fx-padding: 10 20 10 20;
   -fx-max-width: Infinity;
 }
 
-.taxonomy-selection-container {
-  -fx-padding: 10 10 10 10;
+/*noinspection CssInvalidPseudoSelector*/
+.selection-container .button:engaged {
+  -fx-background-color: green;
 }
 
-.taxonomy-selection-container .button {
-  -fx-padding: 10 20 10 20;
-  -fx-max-width: Infinity;
-}
-
-.taxonomy-selection-container .category-label {
+.selection-container .group-label {
   -fx-max-width: Infinity;
   -fx-padding: 30 20 7 20;
   -fx-font-size: 1.2em;

--- a/gui/src/main/resources/views/main-pane-right.fxml
+++ b/gui/src/main/resources/views/main-pane-right.fxml
@@ -5,6 +5,5 @@
 <?import javafx.scene.layout.VBox?>
 <VBox xmlns="http://javafx.com/javafx/20.0.1" xmlns:fx="http://javafx.com/fxml/1"
       fx:controller="io.xj.gui.controllers.MainPaneRightController">
-  <VBox fx:id="taxonomySelectionContainer" styleClass="taxonomy-selection-container" prefWidth="220.0"/>
-  <VBox fx:id="macroSelectionContainer" styleClass="macro-selection-container" prefWidth="220.0"/>
+  <VBox fx:id="selectionContainer" styleClass="selection-container" prefWidth="220.0"/>
 </VBox>

--- a/nexus/src/main/java/io/xj/nexus/craft/macro_main/MacroMainCraftImpl.java
+++ b/nexus/src/main/java/io/xj/nexus/craft/macro_main/MacroMainCraftImpl.java
@@ -26,7 +26,6 @@ import org.slf4j.LoggerFactory;
 import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.UUID;
 
 /**
@@ -66,16 +65,10 @@ public class MacroMainCraftImpl extends CraftImpl implements MacroMainCraft {
 
     //
     // 1. Macro
-    var macroProgram = Objects.nonNull(overrideMacroProgram)
-      ? overrideMacroProgram
-      : chooseMacroProgram();
-    //
-    Integer macroSequenceBindingOffset = Objects.nonNull(overrideMacroProgram)
-      ? fabricator.getSecondMacroSequenceBindingOffset(overrideMacroProgram)
-      : computeMacroSequenceBindingOffset();
+    var macroProgram = chooseMacroProgram();
+    Integer macroSequenceBindingOffset = computeMacroSequenceBindingOffset();
     var macroSequenceBinding = fabricator.getRandomlySelectedSequenceBindingAtOffset(macroProgram, macroSequenceBindingOffset)
       .orElseThrow(() -> new NexusException(String.format("Unable to determine macro sequence binding for Segment[%d]", segment.getId())));
-    //
     var macroSequence = fabricator.sourceMaterial().getProgramSequence(macroSequenceBinding)
       .orElseThrow(() -> new NexusException(String.format("Unable to determine macro sequence for Segment[%d]", segment.getId())));
     //
@@ -93,14 +86,12 @@ public class MacroMainCraftImpl extends CraftImpl implements MacroMainCraft {
     //
     // 2. Main
     var mainProgram = chooseMainProgram();
-    //
     Integer mainSequenceBindingOffset = computeMainProgramSequenceBindingOffset();
     var mainSequenceBinding = fabricator.getRandomlySelectedSequenceBindingAtOffset(mainProgram, mainSequenceBindingOffset)
       .orElseThrow(() -> new NexusException(String.format("Unable to determine main sequence binding for Segment[%d]", segment.getId())));
-    //
     var mainSequence = fabricator.sourceMaterial().getProgramSequence(mainSequenceBinding)
       .orElseThrow(() -> new NexusException(String.format("Unable to determine main sequence for Segment[%d]", segment.getId())));
-
+    //
     var mainChoice = new SegmentChoice();
     mainChoice.setId(UUID.randomUUID());
     mainChoice.setSegmentId(segment.getId());
@@ -242,7 +233,9 @@ public class MacroMainCraftImpl extends CraftImpl implements MacroMainCraft {
    */
   private Integer computeMacroSequenceBindingOffset() throws NexusException {
     if (List.of(SegmentType.INITIAL, SegmentType.NEXT_MACRO).contains(fabricator.getType()))
-      return 0;
+      return Objects.nonNull(overrideMacroProgram)
+        ? fabricator.getSecondMacroSequenceBindingOffset(overrideMacroProgram)
+        : 0;
 
     var previousMacroChoice = fabricator.getMacroChoiceOfPreviousSegment();
     if (previousMacroChoice.isEmpty())

--- a/nexus/src/main/java/io/xj/nexus/fabricator/Fabricator.java
+++ b/nexus/src/main/java/io/xj/nexus/fabricator/Fabricator.java
@@ -170,13 +170,6 @@ public interface Fabricator {
   Optional<SegmentChoice> getCurrentMainChoice();
 
   /**
-   Get the current main program
-
-   @return main program if present
-   */
-  Program getCurrentMainProgram() throws NexusException;
-
-  /**
    Get the sequence targeted by the current main choice
 
    @return current main sequence

--- a/nexus/src/main/java/io/xj/nexus/fabricator/FabricatorImpl.java
+++ b/nexus/src/main/java/io/xj/nexus/fabricator/FabricatorImpl.java
@@ -434,14 +434,6 @@ public class FabricatorImpl implements Fabricator {
   }
 
   @Override
-  public Program getCurrentMainProgram() throws NexusException {
-    return
-      sourceMaterial.getProgram(getCurrentMainChoice()
-          .orElseThrow(() -> new NexusException("No current main choice!")).getProgramId())
-        .orElseThrow(() -> new NexusException("Failed to retrieve current main program!"));
-  }
-
-  @Override
   public Optional<ProgramSequence> getCurrentMainSequence() {
     var mc = getCurrentMainChoice();
     if (mc.isEmpty()) return Optional.empty();

--- a/nexus/src/main/java/io/xj/nexus/work/CraftState.java
+++ b/nexus/src/main/java/io/xj/nexus/work/CraftState.java
@@ -2,7 +2,6 @@ package io.xj.nexus.work;
 
 public enum CraftState {
   INITIAL,
-  READY,
-  GOTO_MACRO,
-  GOTO_MEMES,
+  CONTINUE,
+  REWRITE,
 }

--- a/nexus/src/main/java/io/xj/nexus/work/CraftWork.java
+++ b/nexus/src/main/java/io/xj/nexus/work/CraftWork.java
@@ -147,14 +147,24 @@ public interface CraftWork extends Work {
    @param macroProgram        the macro program to go to
    @param dubbedToChainMicros the chain micros at which to dub
    */
-  void gotoMacroProgram(Program macroProgram, long dubbedToChainMicros);
+  void doOverrideMacro(Program macroProgram, long dubbedToChainMicros);
 
   /**
-   Go to the given set of taxonomy category memes right now
+   Reset the macro program override
+   */
+  void resetOverrideMacro();
+
+  /**
+   Manually go to a specific taxonomy category meme, and force until reset
    https://www.pivotaltracker.com/story/show/186714075
 
-   @param memes               to go to
-   @param dubbedToChainMicros the chain micros at which to dub
+   @param memes specific (assumed allowably) set of taxonomy category memes
    */
-  void gotoTaxonomyCategoryMemes(Collection<String> memes, Long dubbedToChainMicros);
+  void doOverrideMemes(Collection<String> memes, long dubbedToChainMicros);
+
+  /**
+   Reset the taxonomy category memes
+   https://www.pivotaltracker.com/story/show/186714075
+   */
+  void resetOverrideMemes();
 }

--- a/nexus/src/main/java/io/xj/nexus/work/DubWorkImpl.java
+++ b/nexus/src/main/java/io/xj/nexus/work/DubWorkImpl.java
@@ -108,7 +108,7 @@ public class DubWorkImpl implements DubWork {
     // Only ready to dub after at least one craft cycle is completed since the last time we weren't ready to dub
     // Workstation has live performance modulation https://www.pivotaltracker.com/story/show/186003440
     if (!craftWork.isReady()) {
-      LOG.info("Waiting for Craft readiness...");
+      LOG.debug("Waiting for Craft readiness...");
       return;
     }
 

--- a/nexus/src/main/java/io/xj/nexus/work/WorkManager.java
+++ b/nexus/src/main/java/io/xj/nexus/work/WorkManager.java
@@ -105,7 +105,13 @@ public interface WorkManager {
 
    @param macroProgram to go to
    */
-  void gotoMacroProgram(Program macroProgram);
+  void doOverrideMacro(Program macroProgram);
+
+  /**
+   Reset the macro program override
+   https://www.pivotaltracker.com/story/show/186003440
+   */
+  void resetOverrideMacro();
 
   /**
    @return the meme taxonomy from the current template configuration
@@ -113,10 +119,16 @@ public interface WorkManager {
   Optional<MemeTaxonomy> getMemeTaxonomy();
 
   /**
-   Manually go to a specific taxonomy category meme
+   Manually go to a specific taxonomy category meme, and force until reset
    https://www.pivotaltracker.com/story/show/186714075
 
    @param memes specific (assumed allowably) set of taxonomy category memes
    */
-  void gotoTaxonomyCategoryMemes(Collection<String> memes);
+  void doOverrideMemes(Collection<String> memes);
+
+  /**
+   Reset the taxonomy category memes
+   https://www.pivotaltracker.com/story/show/186714075
+   */
+  void resetOverrideMemes();
 }

--- a/nexus/src/main/java/io/xj/nexus/work/WorkManagerImpl.java
+++ b/nexus/src/main/java/io/xj/nexus/work/WorkManagerImpl.java
@@ -177,6 +177,13 @@ public class WorkManagerImpl implements WorkManager {
     );
     LOG.debug("Did initialize audio cache");
 
+    try {
+      entityStore.clear();
+    } catch (Exception e) {
+      LOG.error("Failed to clear entity store", e);
+    }
+    LOG.debug("Did clear entity store");
+
     startedAtMillis.set(System.currentTimeMillis());
     isAudioLoaded.set(false);
     updateState(WorkState.Starting);
@@ -247,10 +254,16 @@ public class WorkManagerImpl implements WorkManager {
   }
 
   @Override
-  public void gotoMacroProgram(Program macroProgram) {
+  public void doOverrideMacro(Program macroProgram) {
     assert Objects.nonNull(craftWork);
     assert Objects.nonNull(dubWork);
-    craftWork.gotoMacroProgram(macroProgram, dubWork.getDubbedToChainMicros().orElse(0L));
+    craftWork.doOverrideMacro(macroProgram, dubWork.getDubbedToChainMicros().orElse(0L));
+  }
+
+  @Override
+  public void resetOverrideMacro() {
+    assert Objects.nonNull(craftWork);
+    craftWork.resetOverrideMacro();
   }
 
   @Override
@@ -265,10 +278,16 @@ public class WorkManagerImpl implements WorkManager {
   }
 
   @Override
-  public void gotoTaxonomyCategoryMemes(Collection<String> memes) {
+  public void doOverrideMemes(Collection<String> memes) {
     assert Objects.nonNull(craftWork);
     assert Objects.nonNull(dubWork);
-    craftWork.gotoTaxonomyCategoryMemes(memes, dubWork.getDubbedToChainMicros().orElse(0L));
+    craftWork.doOverrideMemes(memes, dubWork.getDubbedToChainMicros().orElse(0L));
+  }
+
+  @Override
+  public void resetOverrideMemes() {
+    assert Objects.nonNull(craftWork);
+    craftWork.resetOverrideMemes();
   }
 
   @Override
@@ -278,11 +297,6 @@ public class WorkManagerImpl implements WorkManager {
 
   @Override
   public void reset() {
-    try {
-      entityStore.clear();
-    } catch (Exception e) {
-      LOG.error("Failed to clear entity store", e);
-    }
     craftWork = null;
     dubWork = null;
     shipWork = null;


### PR DESCRIPTION
- User selects one meme from each taxonomy category and presses "Engage" to refabricate segments with those memes.
- When meme override is active, continue forcing these memes until user presses "Reset" button
- User presses a "Reset" button to reset the memes and continue automatic fabrication
- When a set of memes is engaged, these memes appear lit up green in the side panel

https://github.com/xjmusic/workstation/issues/199