### PR TITLE
Workstation Instrument & Audio editor save changes immediately

### DIFF
--- a/gui/src/main/resources/views/content/instrument/instrument-audio-editor.fxml
+++ b/gui/src/main/resources/views/content/instrument/instrument-audio-editor.fxml
@@ -71,13 +71,6 @@
       <Label alignment="CENTER_RIGHT" contentDisplay="TEXT_ONLY" text="Total (Beats)"/>
       <TextField fx:id="fieldTotalBeats" prefHeight="25.0"/>
     </VBox>
-
-    <HBox spacing="10">
-      <Button
-        fx:id="buttonSave"
-        onAction="#handlePressSave"
-        text="Save"/>
-    </HBox>
   </VBox>
 
   <AnchorPane

--- a/gui/src/main/resources/views/content/instrument/instrument-editor.fxml
+++ b/gui/src/main/resources/views/content/instrument/instrument-editor.fxml
@@ -40,13 +40,6 @@
       <Label alignment="CENTER_RIGHT" contentDisplay="TEXT_ONLY" text="Configuration" textAlignment="RIGHT"/>
       <TextArea fx:id="fieldConfig" maxHeight="Infinity"/>
     </VBox>
-
-    <HBox spacing="10">
-      <Button
-        fx:id="buttonSave"
-        onAction="#handlePressSave"
-        text="Save"/>
-    </HBox>
   </VBox>
 
   <AnchorPane


### PR DESCRIPTION
- Editing a Instrument, changes to attribute values are saved as soon as the user clicks outside of (unfocuses) the field
- Editing an Instrument Audio, changes to attribute values are saved as soon as the user clicks outside of (unfocuses) the field
- Editing an Instrument Audio, double-clicking to set the transient position saves changes immediately
- Remove the "Save" button from Instrument editing
- Remove the "Save" button from Instrument audio editing

https://www.pivotaltracker.com/story/show/186983588