### PR TITLE
Workstation config fields should update when it loses focus

### DIFF
--- a/gui/src/main/java/io/xj/gui/controllers/content/instrument/InstrumentEditorController.java
+++ b/gui/src/main/java/io/xj/gui/controllers/content/instrument/InstrumentEditorController.java
@@ -140,10 +140,9 @@ public class InstrumentEditorController extends BrowserController {
     });
     fieldConfig.focusedProperty().addListener((o, ov, v) -> {
       if (!v) {
-        String configString;
         try {
-          configString = new InstrumentConfig(config.get()).toString();
-          update("config", configString);
+          config.set(new InstrumentConfig(config.get()).toString());
+          update("config", config.get());
         } catch (Exception e) {
           LOG.error("Could not parse Instrument Config because {}", e.getMessage());
         }

--- a/gui/src/main/java/io/xj/gui/controllers/template/TemplateEditorController.java
+++ b/gui/src/main/java/io/xj/gui/controllers/template/TemplateEditorController.java
@@ -96,10 +96,9 @@ public class TemplateEditorController extends BrowserController {
     });
     fieldConfig.focusedProperty().addListener((o, ov, v) -> {
       if (!v) {
-        String configString;
         try {
-          configString = new TemplateConfig(config.get()).toString();
-          update("config", configString);
+          config.set(new TemplateConfig(config.get()).toString());
+          update("config", config.get());
         } catch (Exception e) {
           LOG.error("Could not parse Template Config because {}", e.getMessage());
         }


### PR DESCRIPTION
The problem was, the field was updating, but not displaying the new parsed value in the UI.

Now
- Template Editor shows parsed config value after focusing out of config field
- Instrument Editor shows parsed config value after focusing out of config field

https://www.pivotaltracker.com/story/show/187091757