### PR TITLE
Workstation: Tapping Alt should not activate menu shortcuts

### DIFF
--- a/gui/src/main/java/io/xj/gui/controllers/MainMenuController.java
+++ b/gui/src/main/java/io/xj/gui/controllers/MainMenuController.java
@@ -7,11 +7,11 @@ import io.xj.gui.WorkstationGuiFxApplication;
 import io.xj.gui.controllers.fabrication.FabricationSettingsModalController;
 import io.xj.gui.modes.ViewMode;
 import io.xj.gui.services.FabricationService;
-import io.xj.gui.services.SupportService;
 import io.xj.gui.services.LabService;
 import io.xj.gui.services.LabState;
 import io.xj.gui.services.ProjectDescriptor;
 import io.xj.gui.services.ProjectService;
+import io.xj.gui.services.SupportService;
 import io.xj.gui.services.ThemeService;
 import io.xj.gui.services.UIStateService;
 import io.xj.gui.utils.ProjectUtils;
@@ -179,6 +179,7 @@ public class MainMenuController extends ProjectController {
     itemFabricationMainAction.textProperty().bind(fabricationService.mainActionButtonTextProperty().map(this::addLeadingUnderscore));
 
     itemOpenFabricationSettings.disableProperty().bind(guiService.isFabricationSettingsDisabledProperty());
+    itemOpenFabricationSettings.setAccelerator(computeFabricationSettingsAccelerator());
 
     checkboxTailLogs.selectedProperty().bindBidirectional(uiStateService.logsTailingProperty());
     checkboxShowLogs.selectedProperty().bindBidirectional(uiStateService.logsVisibleProperty());
@@ -415,7 +416,7 @@ public class MainMenuController extends ProjectController {
    @return the accelerator
    */
   private KeyCombination computeMainActionButtonAccelerator() {
-    return KeyCombination.valueOf("SHORTCUT+" + (System.getProperty("os.name").toLowerCase().contains("mac") ? "B":"SPACE"));
+    return KeyCombination.valueOf("SHORTCUT+" + (System.getProperty("os.name").toLowerCase().contains("mac") ? "B" : "SPACE"));
   }
 
   /**
@@ -425,6 +426,16 @@ public class MainMenuController extends ProjectController {
    @return the accelerator
    */
   private KeyCombination computeFabricationFollowButtonAccelerator() {
-    return KeyCombination.valueOf("SHORTCUT+ALT+" + (System.getProperty("os.name").toLowerCase().contains("mac") ? "B":"SPACE"));
+    return KeyCombination.valueOf("SHORTCUT+ALT+" + (System.getProperty("os.name").toLowerCase().contains("mac") ? "B" : "SPACE"));
+  }
+
+  /**
+   Compute the accelerator for the fabricator settings button.
+   Depending on the platform, it will be either SHORTCUT+SHIFT+ALT+SPACE or SHORTCUT+SHIFT+ALT+B (on Mac because of conflict).
+
+   @return the accelerator
+   */
+  private KeyCombination computeFabricationSettingsAccelerator() {
+    return KeyCombination.valueOf("SHORTCUT+SHIFT+ALT+" + (System.getProperty("os.name").toLowerCase().contains("mac") ? "B" : "SPACE"));
   }
 }

--- a/gui/src/main/resources/views/main-menu.fxml
+++ b/gui/src/main/resources/views/main-menu.fxml
@@ -29,91 +29,118 @@
   xmlns:fx="http://javafx.com/fxml/1"
   styleClass="main-menu">
 
-  <MenuBar
-    VBox.vgrow="NEVER">
+  <MenuBar VBox.vgrow="NEVER">
 
-    <Menu text="_Project">
-      <MenuItem onAction="#handleProjectNew" text="_New..."/>
-      <MenuItem onAction="#handleProjectOpen" text="_Open..."/>
-      <Menu fx:id="menuOpenRecent" text="Open _Recent">
+    <Menu text="Project" mnemonicParsing="false">
+      <MenuItem onAction="#handleProjectNew" text="New..."  mnemonicParsing="false">
+        <accelerator>
+          <KeyCodeCombination shortcut="DOWN" code="N" control="UP" meta="UP" shift="UP" alt="UP"/>
+        </accelerator>
+      </MenuItem>
+      <MenuItem onAction="#handleProjectOpen" text="Open..." mnemonicParsing="false">
+        <accelerator>
+          <KeyCodeCombination shortcut="DOWN" code="O" control="UP" meta="UP" shift="UP" alt="UP"/>
+        </accelerator>
+      </MenuItem>
+      <Menu fx:id="menuOpenRecent" text="Open Recent" mnemonicParsing="false">
         <!-- Recent projects will be added here dynamically -->
       </Menu>
-      <MenuItem fx:id="itemProjectClose" onAction="#handleProjectClose" text="_Close"/>
+      <MenuItem fx:id="itemProjectClose" onAction="#handleProjectClose" text="Close" mnemonicParsing="false">
+        <accelerator>
+          <KeyCodeCombination shortcut="DOWN" code="W" control="UP" meta="UP" shift="UP" alt="UP"/>
+        </accelerator>
+      </MenuItem>
       <SeparatorMenuItem mnemonicParsing="false"/>
-      <MenuItem fx:id="itemProjectSave" onAction="#handleProjectSave" text="_Save">
+      <MenuItem fx:id="itemProjectSave" onAction="#handleProjectSave" text="Save" mnemonicParsing="false">
           <accelerator>
             <KeyCodeCombination alt="UP" code="S" control="UP" meta="UP" shift="UP" shortcut="DOWN"/>
           </accelerator>
       </MenuItem>
-      <MenuItem fx:id="itemProjectCleanup" onAction="#handleProjectCleanup" text="Clean_up"/>
+      <MenuItem fx:id="itemProjectCleanup" onAction="#handleProjectCleanup" text="Cleanup" mnemonicParsing="false"/>
       <SeparatorMenuItem mnemonicParsing="false"/>
-      <MenuItem onAction="#handleProjectClone" text="C_lone..."/>
-      <MenuItem fx:id="itemProjectPush" onAction="#handleProjectPush" text="_Push"/>
+      <MenuItem onAction="#handleProjectClone" text="Clone..." mnemonicParsing="false">
+        <accelerator>
+          <KeyCodeCombination shortcut="DOWN" code="O" control="UP" meta="UP" shift="DOWN" alt="UP"/>
+        </accelerator>
+      </MenuItem>
+      <MenuItem fx:id="itemProjectPush" onAction="#handleProjectPush" text="Push" mnemonicParsing="false">
+        <accelerator>
+          <KeyCodeCombination shortcut="DOWN" code="P" control="UP" meta="UP" shift="DOWN" alt="UP"/>
+        </accelerator>
+      </MenuItem>
       <SeparatorMenuItem mnemonicParsing="false"/>
-      <MenuItem onAction="#onQuit" text="E_xit"/>
+      <MenuItem onAction="#onQuit" text="Exit" mnemonicParsing="false">
+        <accelerator>
+          <KeyCodeCombination shortcut="DOWN" code="Q" control="UP" meta="UP" shift="UP" alt="UP"/>
+        </accelerator>
+      </MenuItem>
     </Menu>
 
-    <Menu fx:id="menuFabrication" text="_Fabrication">
-      <MenuItem fx:id="itemFabricationMainAction" onAction="#handleFabricationMainAction" text="_Start"/>
-      <CheckMenuItem fx:id="checkboxFabricationFollow" text="_Follow"/>
+    <Menu fx:id="menuFabrication" text="Fabrication" mnemonicParsing="false">
+      <MenuItem fx:id="itemFabricationMainAction" onAction="#handleFabricationMainAction" text="Start" mnemonicParsing="false"/>
+      <CheckMenuItem fx:id="checkboxFabricationFollow" text="Follow" mnemonicParsing="false"/>
       <SeparatorMenuItem mnemonicParsing="false"/>
-      <MenuItem fx:id="itemOpenFabricationSettings" onAction="#handleOpenFabricationSettings" text="S_ettings">
+      <MenuItem fx:id="itemOpenFabricationSettings" onAction="#handleOpenFabricationSettings" text="Settings" mnemonicParsing="false">
         <accelerator>
           <KeyCodeCombination alt="UP" code="E" control="UP" meta="UP" shift="UP" shortcut="DOWN"/>
         </accelerator>
       </MenuItem>
     </Menu>
 
-    <Menu text="_View">
+    <Menu text="View" mnemonicParsing="false">
       <fx:define>
         <ToggleGroup fx:id="menuViewModeToggleGroup"/>
       </fx:define>
-      <RadioMenuItem text="_Content" fx:id="menuViewModeContent" toggleGroup="$menuViewModeToggleGroup">
+      <RadioMenuItem text="Content" fx:id="menuViewModeContent" toggleGroup="$menuViewModeToggleGroup" mnemonicParsing="false">
         <accelerator>
           <KeyCodeCombination alt="UP" code="F3" control="UP" meta="UP" shift="UP" shortcut="UP"/>
         </accelerator>
       </RadioMenuItem>
-      <RadioMenuItem text="_Templates" fx:id="menuViewModeTemplates" toggleGroup="$menuViewModeToggleGroup">
+      <RadioMenuItem text="Templates" fx:id="menuViewModeTemplates" toggleGroup="$menuViewModeToggleGroup" mnemonicParsing="false">
         <accelerator>
           <KeyCodeCombination alt="UP" code="F4" control="UP" meta="UP" shift="UP" shortcut="UP"/>
         </accelerator>
       </RadioMenuItem>
-      <RadioMenuItem text="_Fabrication" fx:id="menuViewModeFabrication" toggleGroup="$menuViewModeToggleGroup">
+      <RadioMenuItem text="Fabrication" fx:id="menuViewModeFabrication" toggleGroup="$menuViewModeToggleGroup" mnemonicParsing="false">
         <accelerator>
           <KeyCodeCombination alt="UP" code="F5" control="UP" meta="UP" shift="UP" shortcut="UP"/>
         </accelerator>
       </RadioMenuItem>
       <SeparatorMenuItem mnemonicParsing="false"/>
-      <CheckMenuItem fx:id="checkboxShowLogs" text="Show _Logs">
+      <CheckMenuItem fx:id="checkboxShowLogs" text="Show Logs" mnemonicParsing="false">
         <accelerator>
           <KeyCodeCombination alt="UP" code="F10" control="UP" meta="UP" shift="UP" shortcut="UP"/>
         </accelerator>
       </CheckMenuItem>
-      <CheckMenuItem fx:id="checkboxTailLogs" disable="true" selected="true" text="Logs Auto-_scroll">
+      <CheckMenuItem fx:id="checkboxTailLogs" disable="true" selected="true" text="Logs Auto-scroll" mnemonicParsing="false">
         <accelerator>
           <KeyCodeCombination alt="UP" code="F10" control="UP" meta="UP" shift="UP" shortcut="DOWN"/>
         </accelerator>
       </CheckMenuItem>
-      <Menu text="Log Le_vel">
+      <Menu text="Log Level" mnemonicParsing="false">
         <fx:define>
           <ToggleGroup fx:id="logLevelToggleGroup"/>
         </fx:define>
-        <RadioMenuItem text="_Debug" fx:id="logLevelDebug" onAction="#handleSetLogLevel"
-                       toggleGroup="$logLevelToggleGroup"/>
-        <RadioMenuItem text="_Info" fx:id="logLevelInfo" onAction="#handleSetLogLevel"
-                       toggleGroup="$logLevelToggleGroup"/>
-        <RadioMenuItem text="_Warn" fx:id="logLevelWarn" onAction="#handleSetLogLevel"
-                       toggleGroup="$logLevelToggleGroup"/>
-        <RadioMenuItem text="_Error" fx:id="logLevelError" onAction="#handleSetLogLevel"
-                       toggleGroup="$logLevelToggleGroup"/>
+        <RadioMenuItem text="Debug" fx:id="logLevelDebug" onAction="#handleSetLogLevel"
+                       toggleGroup="$logLevelToggleGroup" mnemonicParsing="false"/>
+        <RadioMenuItem text="Info" fx:id="logLevelInfo" onAction="#handleSetLogLevel"
+                       toggleGroup="$logLevelToggleGroup" mnemonicParsing="false"/>
+        <RadioMenuItem text="Warn" fx:id="logLevelWarn" onAction="#handleSetLogLevel"
+                       toggleGroup="$logLevelToggleGroup" mnemonicParsing="false"/>
+        <RadioMenuItem text="Error" fx:id="logLevelError" onAction="#handleSetLogLevel"
+                       toggleGroup="$logLevelToggleGroup" mnemonicParsing="false"/>
       </Menu>
     </Menu>
 
-    <Menu text="_Help">
-      <MenuItem onAction="#onLaunchDiscord" text="_Discord"/>
-      <MenuItem onAction="#onLaunchUserGuide" text="User _Guide"/>
+    <Menu text="Help" mnemonicParsing="false">
+      <MenuItem onAction="#onLaunchDiscord" text="Discord" mnemonicParsing="false"/>
+      <MenuItem onAction="#onLaunchUserGuide" text="User Guide">
+        <accelerator>
+          <KeyCodeCombination alt="UP" code="F1" control="UP" meta="UP" shift="UP" shortcut="UP"/>
+        </accelerator>
+      </MenuItem>
       <SeparatorMenuItem mnemonicParsing="false"/>
-      <MenuItem onAction="#handleAbout" text="_About"/>
+      <MenuItem onAction="#handleAbout" text="About" mnemonicParsing="false"/>
     </Menu>
 
   </MenuBar>


### PR DESCRIPTION
Solution: remove all mnemomic parsing for menus, and rely on accelerators (like Ctrl+S for save, all these are displayed in the menu next to each item)

https://www.pivotaltracker.com/story/show/187225858