### PR TITLE
Fix: Set Audio Transient while waveform is scrolled to the right

### DIFF
--- a/gui/src/main/java/io/xj/gui/controllers/content/instrument/InstrumentAudioEditorController.java
+++ b/gui/src/main/java/io/xj/gui/controllers/content/instrument/InstrumentAudioEditorController.java
@@ -35,6 +35,7 @@ import javafx.scene.image.ImageView;
 import javafx.scene.image.PixelWriter;
 import javafx.scene.image.WritableImage;
 import javafx.scene.input.MouseEvent;
+import javafx.scene.layout.StackPane;
 import javafx.scene.layout.VBox;
 import javafx.scene.paint.Color;
 import javafx.util.converter.NumberStringConverter;
@@ -126,6 +127,9 @@ public class InstrumentAudioEditorController extends BrowserController {
 
   @FXML
   ScrollPane waveformScrollPane;
+
+  @FXML
+  StackPane waveformContainer;
 
   @FXML
   ImageView waveform;
@@ -240,7 +244,7 @@ public class InstrumentAudioEditorController extends BrowserController {
 
     isSettingTransient.addListener((o, ov, active) -> {
       setTransientButton.pseudoClassStateChanged(OPEN_PSEUDO_CLASS, active);
-      waveformScrollPane.setCursor(active ? javafx.scene.Cursor.CROSSHAIR : javafx.scene.Cursor.DEFAULT);
+      waveformContainer.setCursor(active ? javafx.scene.Cursor.CROSSHAIR : javafx.scene.Cursor.DEFAULT);
     });
   }
 
@@ -280,7 +284,7 @@ public class InstrumentAudioEditorController extends BrowserController {
   }
 
   @FXML
-  private void handleClickedWaveformScrollPane(MouseEvent event) {
+  private void handleClickedWaveformContainer(MouseEvent event) {
     if (audioInMemory.isNull().get()) return;
     if (isSettingTransient.not().get()) return;
 

--- a/gui/src/main/resources/styles/default-theme.css
+++ b/gui/src/main/resources/styles/default-theme.css
@@ -429,11 +429,11 @@
   -fx-fill: #404040;
 }
 
-.waveform-container {
+.waveform-scroll-pane {
   -fx-background-color: #101010;
 }
 
-.waveform-container > .viewport {
+.waveform-scroll-pane > .viewport {
   -fx-background-color: transparent;
 }
 

--- a/gui/src/main/resources/views/content/instrument/instrument-audio-editor.fxml
+++ b/gui/src/main/resources/views/content/instrument/instrument-audio-editor.fxml
@@ -13,6 +13,7 @@
 <?import javafx.scene.layout.AnchorPane?>
 <?import javafx.scene.layout.HBox?>
 <?import javafx.scene.layout.Priority?>
+<?import javafx.scene.layout.StackPane?>
 <?import javafx.scene.layout.VBox?>
 <SplitPane
     fx:controller="io.xj.gui.controllers.content.instrument.InstrumentAudioEditorController"
@@ -104,12 +105,16 @@
         hbarPolicy="ALWAYS"
         fitToWidth="true"
         fitToHeight="true"
-        styleClass="waveform-container"
-        onMouseClicked="#handleClickedWaveformScrollPane">
-      <ImageView
-          fx:id="waveform"
-          preserveRatio="true">
-      </ImageView>
+        styleClass="waveform-scroll-pane">
+      <StackPane
+          fx:id="waveformContainer"
+          onMouseClicked="#handleClickedWaveformContainer"
+          alignment="CENTER_LEFT">
+        <ImageView
+            fx:id="waveform"
+            preserveRatio="true">
+        </ImageView>
+      </StackPane>
     </ScrollPane>
 
     <Button


### PR DESCRIPTION
The first version of this had a bug where it didn't set the right position when the waveform is zoomed in and the scroll pane scrolled to the right.

Instrument Audio Editor Transient section and setting is special function
https://www.pivotaltracker.com/story/show/187225777