### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,9 @@ This project is built with Gradle. To run the XJ music workstation, run:
 
 You should then see the JavaFX GUI open the main window.
 
-Press the hamburger menu next to the last button to open the fabrication configuration pane. In the field called "Input Template Key" you'll see the default value `slaps_lofi` but you can also try the
-values `space_binaural` or `space_flow`
+Click the Project menu on the top left-hand side and choose Clone to bring up a selection of four demo projects. Click OK to begin cloning the chosen project onto your machine. Once done, the main window will display all of the libraries included in your select project in the Content tab. Click the Fabrication tab in the top right-hand corner to switch to the Fabrication tab, there you can click Start to begin playing the project. 
+
+Click here for a video walkthrough! https://www.youtube.com/watch?v=aWUKu5G5OZk
 
 ## Architecture
 


### PR DESCRIPTION
Updated Running the Application section to remove references to fabrication keys, instead giving a walkthrough of cloning projects, tabbing over from Content to Fabrication, and playing a demo project, with a link to the video tutorial placed at the end.