### PR TITLE
Duplicating a Template, should use provided name

### DIFF
--- a/nexus/src/main/java/io/xj/nexus/project/ProjectManagerImpl.java
+++ b/nexus/src/main/java/io/xj/nexus/project/ProjectManagerImpl.java
@@ -901,9 +901,15 @@ public class ProjectManagerImpl implements ProjectManager {
   public Template duplicateTemplate(UUID fromId, String name) throws Exception {
     var source = content.get().getTemplate(fromId).orElseThrow(() -> new NexusException("Template not found"));
 
+    // New Create a template, increment a numerical suffix to make each sequence unique, e.g. "New Template 2" then "New Template 3"
+    var existingTemplates = content.get().getTemplates();
+    var existingNames = existingTemplates.stream().map(Template::getName).collect(Collectors.toSet());
+    var actualName = FormatUtils.iterateNumericalSuffixFromExisting(existingNames, name);
+
     // Duplicate the Template
     var duplicate = new Template();
     duplicate.setId(UUID.randomUUID());
+    duplicate.setName(actualName);
     entityFactory.setAllEmptyAttributes(source, duplicate);
     content.get().put(duplicate);
 
@@ -918,9 +924,14 @@ public class ProjectManagerImpl implements ProjectManager {
   public Library duplicateLibrary(UUID fromId, String name) throws Exception {
     var source = content.get().getLibrary(fromId).orElseThrow(() -> new NexusException("Library not found"));
 
+    // New Create a library, increment a numerical suffix to make each sequence unique, e.g. "New Library 2" then "New Library 3"
+    var existingLibraries = content.get().getLibraries();
+    var existingNames = existingLibraries.stream().map(Library::getName).collect(Collectors.toSet());
+    var actualName = FormatUtils.iterateNumericalSuffixFromExisting(existingNames, name);
+
     // Duplicate the Library and put it in the store
     var library = entityFactory.duplicate(source);
-    library.setName(name);
+    library.setName(actualName);
     content.get().put(library);
 
     // Duplicate the Library's Programs
@@ -940,12 +951,17 @@ public class ProjectManagerImpl implements ProjectManager {
   @SuppressWarnings("CollectionAddAllCanBeReplacedWithConstructor")
   @Override
   public Program duplicateProgram(UUID fromId, UUID libraryId, String name) throws Exception {
-    var program = content.get().getProgram(fromId).orElseThrow(() -> new NexusException("Program not found"));
+    var source = content.get().getProgram(fromId).orElseThrow(() -> new NexusException("Program not found"));
+
+    // New Create a program, increment a numerical suffix to make each sequence unique, e.g. "New Program 2" then "New Program 3"
+    var existingProgramsOfLibrary = content.get().getProgramsOfLibrary(source.getLibraryId());
+    var existingNames = existingProgramsOfLibrary.stream().map(Program::getName).collect(Collectors.toSet());
+    var actualName = FormatUtils.iterateNumericalSuffixFromExisting(existingNames, name);
 
     // Duplicate Program
-    var duplicateProgram = entityFactory.duplicate(program);
+    var duplicateProgram = entityFactory.duplicate(source);
     duplicateProgram.setLibraryId(libraryId);
-    duplicateProgram.setName(name);
+    duplicateProgram.setName(actualName);
 
     // Prepare all maps of duplicated sub-entities to avoid putting more than once to store
     Map<UUID, ProgramMeme> duplicatedProgramMemes = new HashMap<>();
@@ -1115,10 +1131,15 @@ public class ProjectManagerImpl implements ProjectManager {
   public Instrument duplicateInstrument(UUID fromId, UUID libraryId, String name) throws Exception {
     var source = content.get().getInstrument(fromId).orElseThrow(() -> new NexusException("Instrument not found"));
 
+    // New Create a instrument, increment a numerical suffix to make each sequence unique, e.g. "New Instrument 2" then "New Instrument 3"
+    var existingInstrumentsOfLibrary = content.get().getInstrumentsOfLibrary(source.getLibraryId());
+    var existingNames = existingInstrumentsOfLibrary.stream().map(Instrument::getName).collect(Collectors.toSet());
+    var actualName = FormatUtils.iterateNumericalSuffixFromExisting(existingNames, name);
+
     // Duplicate the Instrument
     var instrument = entityFactory.duplicate(source);
     instrument.setLibraryId(libraryId);
-    instrument.setName(name);
+    instrument.setName(actualName);
 
     // Duplicate the Instrument's Audios
     var duplicatedAudios = entityFactory.duplicateAll(content.get().getAudiosOfInstrument(fromId), Set.of(instrument));

--- a/nexus/src/test/java/io/xj/nexus/project/ProjectManagerImplTest.java
+++ b/nexus/src/test/java/io/xj/nexus/project/ProjectManagerImplTest.java
@@ -456,11 +456,25 @@ class ProjectManagerImplTest {
     assertEquals(otherLibrary.getId(), result.orElseThrow().getLibraryId());
   }
 
+  /**
+   Duplicating a Template, should use provided name https://github.com/xjmusic/workstation/issues/342
+   */
   @Test
   void duplicateTemplate() throws Exception {
     var duplicate = subject.duplicateTemplate(UUID.fromString("6cfd24de-dc92-436e-9a7e-def8c9e2d351"), "Duplicated Template");
 
+    assertEquals("Duplicated Template", duplicate.getName());
     assertEquals(1, subject.getContent().getBindingsOfTemplate(duplicate.getId()).size());
+  }
+
+  /**
+   Duplicating a Template, should enumerate to next available unique name https://github.com/xjmusic/workstation/issues/342
+   */
+  @Test
+  void duplicateTemplate_enumeratesToNextUniqueName() throws Exception {
+    var duplicate = subject.duplicateTemplate(UUID.fromString("6cfd24de-dc92-436e-9a7e-def8c9e2d351"), "test1");
+
+    assertEquals("test1 2", subject.getContent().getTemplate(duplicate.getId()).orElseThrow().getName());
   }
 
   @Test
@@ -582,6 +596,16 @@ class ProjectManagerImplTest {
     assertEquals("Chord Fm", instrument2_audio.getName());
   }
 
+  /**
+   Duplicating a Library, should enumerate to next available unique name https://github.com/xjmusic/workstation/issues/342
+   */
+  @Test
+  void duplicateLibrary_enumeratesToNextUniqueName() throws Exception {
+    var duplicate = subject.duplicateLibrary(UUID.fromString("aa613771-358d-4960-b5de-690ff6fd3a55"), "leaves");
+
+    assertEquals("leaves 2", subject.getContent().getLibrary(duplicate.getId()).orElseThrow().getName());
+  }
+
   @Test
   void duplicateProgram() throws Exception {
     var duplicate1 = subject.duplicateProgram(UUID.fromString("7ad65895-27b8-453d-84f1-ef2a2a2f09eb"), UUID.fromString("aa613771-358d-4960-b5de-690ff6fd3a55"), "Duplicated Program 1");
@@ -676,6 +700,16 @@ class ProjectManagerImplTest {
     assertEquals("Bb", program2_sequence_chord2_voicing1.getNotes());
     var program2_sequence_chord2_voicing2 = program2_sequence_chord2_voicings.get(1);
     assertEquals("G", program2_sequence_chord2_voicing2.getNotes());
+  }
+
+  /**
+   Duplicating a Program, should enumerate to next available unique name https://github.com/xjmusic/workstation/issues/342
+   */
+  @Test
+  void duplicateProgram_enumeratesToNextUniqueName() throws Exception {
+    var duplicate = subject.duplicateProgram(UUID.fromString("7ad65895-27b8-453d-84f1-ef2a2a2f09eb"), UUID.fromString("aa613771-358d-4960-b5de-690ff6fd3a55"), "coconuts");
+
+    assertEquals("coconuts 2", subject.getContent().getProgram(duplicate.getId()).orElseThrow().getName());
   }
 
   @Test
@@ -784,5 +818,15 @@ class ProjectManagerImplTest {
     assertEquals(1, subject.getContent().getAudiosOfInstrument(instrument2.getId()).size());
     var instrument2_audio = subject.getContent().getAudiosOfInstrument(instrument2.getId()).stream().findFirst().orElseThrow();
     assertEquals("Chord Fm", instrument2_audio.getName());
+  }
+
+  /**
+   Duplicating an Instrument, should enumerate to next available unique name https://github.com/xjmusic/workstation/issues/342
+   */
+  @Test
+  void duplicateInstrument_enumeratesToNextUniqueName() throws Exception {
+    var duplicate = subject.duplicateInstrument(UUID.fromString("9097d757-ae8f-4d68-b449-8ec96602ca83"), UUID.fromString("aa613771-358d-4960-b5de-690ff6fd3a55"), "808 Drums");
+
+    assertEquals("808 Drums 2", subject.getContent().getInstrument(duplicate.getId()).orElseThrow().getName());
   }
 }


### PR DESCRIPTION
- Use the name from the duplicate modal
- If name already exists, enumerate copies like "Copy of Template 1", "Copy of Template 2"
- Also ensure this behavior for duplicating a Program
- Also ensure this behavior for duplicating an Instrument
- Also ensure this behavior for duplicating a Library

Resolves https://github.com/xjmusic/workstation/issues/342