### PR TITLE
Timeline empty region at bottom should match rest of background

### DIFF
--- a/gui/src/main/java/io/xj/gui/controllers/fabrication/FabricationTimelineController.java
+++ b/gui/src/main/java/io/xj/gui/controllers/fabrication/FabricationTimelineController.java
@@ -99,6 +99,9 @@ public class FabricationTimelineController extends ProjectController {
   ScrollPane scrollPane;
 
   @FXML
+  AnchorPane timelineContainer;
+
+  @FXML
   HBox segmentPositionRow;
 
   @FXML
@@ -161,6 +164,8 @@ public class FabricationTimelineController extends ProjectController {
     scrollPane.hbarPolicyProperty().bind(fabricationService.followPlaybackProperty().map(followPlayback -> followPlayback ? ScrollPane.ScrollBarPolicy.NEVER : ScrollPane.ScrollBarPolicy.AS_NEEDED));
 
     fabricationService.stateProperty().addListener((o, ov, value) -> handleUpdateFabricationStatus(value));
+
+    timelineContainer.minHeightProperty().bind(scrollPane.heightProperty().subtract(6));
 
     resetTimeline();
   }

--- a/gui/src/main/resources/styles/default-theme.css
+++ b/gui/src/main/resources/styles/default-theme.css
@@ -142,8 +142,8 @@
   -fx-text-fill: red;
 }
 
-.main-timeline,
-.timeline-position-spacer {
+.timeline-container,
+.timeline-container .viewport {
   -fx-background-color: #202020;
 }
 

--- a/gui/src/main/resources/views/fabrication/fabrication-timeline.fxml
+++ b/gui/src/main/resources/views/fabrication/fabrication-timeline.fxml
@@ -21,21 +21,10 @@
         fx:id="scrollPane"
         xmlns="http://javafx.com/javafx/20.0.1"
         xmlns:fx="http://javafx.com/fxml/1"
-        VBox.vgrow="ALWAYS"
-        HBox.hgrow="ALWAYS"
-        maxHeight="Infinity"
-        maxWidth="Infinity">
-      <StackPane
-          VBox.vgrow="ALWAYS"
-          HBox.hgrow="ALWAYS"
-          maxHeight="Infinity"
-          maxWidth="Infinity">
+        styleClass="timeline-container">
+      <StackPane>
         <AnchorPane
-            VBox.vgrow="ALWAYS"
-            HBox.hgrow="ALWAYS"
-            maxHeight="Infinity"
-            maxWidth="Infinity"
-            style="-fx-background-color: red;">
+            fx:id="timelineContainer">
           <HBox fx:id="segmentPositionRow" maxHeight="8" minHeight="8" styleClass="timeline-position-indicator"
                 AnchorPane.topAnchor="0" AnchorPane.leftAnchor="0" AnchorPane.rightAnchor="0">
             <Rectangle fx:id="timelineRegion1Past" fill="#17EF1720" height="8"/>


### PR DESCRIPTION
- This lighter gray area should not appear
- Timeline segments should vertically span entire timeline
- Timeline doesn't show messages for segment with no messages

Resolves #357
Resolves #360