### PR TITLE
All workstation CI uses platform matrix

### DIFF
--- a/.github/workflows/workstation_ci.yml
+++ b/.github/workflows/workstation_ci.yml
@@ -15,7 +15,11 @@ jobs:
     name: Workstation CI
     runs-on: ubuntu-22.04
     permissions: write-all
-
+    strategy:
+      matrix:
+        os: [ ubuntu-latest, macos-13, macos-14, windows-latest ]
+        java: [ '17' ]
+      fail-fast: false
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/workstation_ci.yml
+++ b/.github/workflows/workstation_ci.yml
@@ -12,7 +12,7 @@ jobs:
     env:
       REPO_TOKEN: ${{ secrets.REPO_TOKEN }}
       REPO_USERNAME: ${{ secrets.REPO_USERNAME }}
-    name: Workstation CI
+    name: Workstation Tests
     runs-on: ubuntu-22.04
     permissions: write-all
     strategy:

--- a/.github/workflows/workstation_distro.yml
+++ b/.github/workflows/workstation_distro.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   verify:
-    name: Verify
+    name: Workstation Tests
     env:
       REPO_TOKEN: ${{ secrets.REPO_TOKEN }}
       REPO_USERNAME: ${{ secrets.REPO_USERNAME }}

--- a/.github/workflows/workstation_distro.yml
+++ b/.github/workflows/workstation_distro.yml
@@ -13,6 +13,11 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.get-version.outputs.version }}
+    strategy:
+      matrix:
+        os: [ ubuntu-latest, macos-13, macos-14, windows-latest ]
+        java: [ '17' ]
+      fail-fast: false
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/workstation_pr.yml
+++ b/.github/workflows/workstation_pr.yml
@@ -10,7 +10,7 @@ jobs:
     env:
       REPO_TOKEN: ${{ secrets.REPO_TOKEN }}
       REPO_USERNAME: ${{ secrets.REPO_USERNAME }}
-    name: Gradle
+    name: Workstation Tests
     runs-on: ubuntu-latest
     permissions: read-all
     strategy:

--- a/.github/workflows/workstation_pr.yml
+++ b/.github/workflows/workstation_pr.yml
@@ -13,7 +13,11 @@ jobs:
     name: Gradle
     runs-on: ubuntu-latest
     permissions: read-all
-
+    strategy:
+      matrix:
+        os: [ ubuntu-latest, macos-13, macos-14, windows-latest ]
+        java: [ '17' ]
+      fail-fast: false
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/workstation/build.gradle
+++ b/workstation/build.gradle
@@ -218,16 +218,16 @@ jpackage {
     }
 }
 
-allprojects {
-    group = 'io.xj'
-
+java {
     sourceCompatibility = JavaVersion.VERSION_17
     targetCompatibility = JavaVersion.VERSION_17
+}
 
-    tasks.withType(JavaCompile).tap {
-        configureEach {
-            options.encoding = 'UTF-8'
-        }
+group = 'io.xj'
+
+tasks.withType(JavaCompile).tap {
+    configureEach {
+        options.encoding = 'UTF-8'
     }
 }
 


### PR DESCRIPTION
Run all CI jobs on Linux, MacOS 13, MacOS 14, and Windows