### PR TITLE
Engine cleanup with C++ best practices

### DIFF
--- a/engine/include/xjmusic/content/ContentEntityStore.h
+++ b/engine/include/xjmusic/content/ContentEntityStore.h
@@ -100,10 +100,10 @@ namespace XJ {
 
     /**
      * Deserialize a ContentEntityStore object from a JSON file
-     * @param file  The JSON file to deserialize
+     * @param input  The JSON file to deserialize
      * @return      The deserialized ContentEntityStore object
      */
-    explicit ContentEntityStore(std::ifstream &file);
+    explicit ContentEntityStore(std::ifstream &input);
 
     /**
      * Deserialize a ContentEntityStore object from a JSON string

--- a/engine/include/xjmusic/craft/BackgroundCraft.h
+++ b/engine/include/xjmusic/craft/BackgroundCraft.h
@@ -26,7 +26,7 @@ namespace XJ {
     /**
      perform craft for the current segment
      */
-    void doWork();
+    void doWork() const;
   };
 
 }// namespace XJ

--- a/engine/include/xjmusic/craft/BackgroundCraft.h
+++ b/engine/include/xjmusic/craft/BackgroundCraft.h
@@ -18,7 +18,7 @@ namespace XJ {
 
      @param instrument for which to craft
      */
-    void craftBackground(const Instrument *instrument);
+    void craftBackground(const Instrument *instrument) const;
 
   public:
     explicit BackgroundCraft(Fabricator *fabricator);

--- a/engine/include/xjmusic/craft/TransitionCraft.h
+++ b/engine/include/xjmusic/craft/TransitionCraft.h
@@ -56,7 +56,7 @@ namespace XJ {
      @return instrument audios
      */
     std::set<const InstrumentAudio *>
-    selectAudiosForInstrument(const Instrument *instrument, std::set<std::string> names);
+    selectAudiosForInstrument(const Instrument *instrument, std::set<std::string> names) const;
 
   };
 

--- a/engine/include/xjmusic/craft/TransitionCraft.h
+++ b/engine/include/xjmusic/craft/TransitionCraft.h
@@ -48,7 +48,7 @@ namespace XJ {
      @param tempo      of main program
      @param instrument of percussion loop instrument to craft
      */
-    void craftTransition(double tempo, const Instrument *instrument);
+    void craftTransition(double tempo, const Instrument *instrument) const;
 
     /**
      Select audios for instrument having the given event names

--- a/engine/include/xjmusic/craft/TransitionCraft.h
+++ b/engine/include/xjmusic/craft/TransitionCraft.h
@@ -24,7 +24,7 @@ namespace XJ {
     /**
      perform craft for the current segment
      */
-    void doWork();
+    void doWork() const;
 
     /**
      Is this a big-transition segment? (next main or next macro)

--- a/engine/include/xjmusic/fabricator/MarbleBag.h
+++ b/engine/include/xjmusic/fabricator/MarbleBag.h
@@ -101,12 +101,12 @@ namespace XJ {
     /**
      * @return true if the marble bag is completely empty
      */
-    bool empty();
+    bool empty() const;
 
     /**
      * @return true if there are any marbles in the bag
      */
-    bool isPresent();
+    bool isPresent() const;
 
     /**
      * Pick a marble from the specified phase

--- a/engine/include/xjmusic/fabricator/MarbleBag.h
+++ b/engine/include/xjmusic/fabricator/MarbleBag.h
@@ -96,7 +96,7 @@ namespace XJ {
     /**
      * Display as string
      */
-    std::string toString();
+    std::string toString() const;
 
     /**
      * @return true if the marble bag is completely empty

--- a/engine/include/xjmusic/fabricator/MarbleBag.h
+++ b/engine/include/xjmusic/fabricator/MarbleBag.h
@@ -91,7 +91,7 @@ namespace XJ {
      *
      * @return {number}
      */
-    int size();
+    int size() const;
 
     /**
      * Display as string

--- a/engine/include/xjmusic/fabricator/NotePicker.h
+++ b/engine/include/xjmusic/fabricator/NotePicker.h
@@ -65,7 +65,7 @@ namespace XJ {
      @param range   towards which seeking will optimize
      @param options from which to select better notes
      */
-    Note seekInversion(Note source, NoteRange range, std::set<Note> options);
+    Note seekInversion(Note source, NoteRange range, std::set<Note> options) const;
 
     /**
      Pick a random instrument note from the available notes in the voicing

--- a/engine/include/xjmusic/fabricator/NotePicker.h
+++ b/engine/include/xjmusic/fabricator/NotePicker.h
@@ -75,7 +75,7 @@ namespace XJ {
      @param fromNotes to pick from
      @return a random note from the voicing
      */
-    std::optional<Note> pickRandom(std::set<Note> fromNotes);
+    static std::optional<Note> pickRandom(std::set<Note> fromNotes);
 
   };
 

--- a/engine/include/xjmusic/fabricator/NotePicker.h
+++ b/engine/include/xjmusic/fabricator/NotePicker.h
@@ -65,7 +65,7 @@ namespace XJ {
      @param range   towards which seeking will optimize
      @param options from which to select better notes
      */
-    Note seekInversion(Note source, NoteRange range, std::set<Note> options) const;
+    Note seekInversion(Note source, const NoteRange &range, const std::set<Note> &options) const;
 
     /**
      Pick a random instrument note from the available notes in the voicing

--- a/engine/include/xjmusic/fabricator/RankedNote.h
+++ b/engine/include/xjmusic/fabricator/RankedNote.h
@@ -31,7 +31,7 @@ namespace XJ {
      * Get the tones of this note
      * @return  the tones
      */
-    Note getTones();
+    Note getTones() const;
 
     /**
      * Get the delta of this note

--- a/engine/include/xjmusic/fabricator/RankedNote.h
+++ b/engine/include/xjmusic/fabricator/RankedNote.h
@@ -37,7 +37,7 @@ namespace XJ {
      * Get the delta of this note
      * @return  the delta
      */
-    int getDelta();
+    int getDelta() const;
 
   };
 

--- a/engine/include/xjmusic/fabricator/SegmentRetrospective.h
+++ b/engine/include/xjmusic/fabricator/SegmentRetrospective.h
@@ -122,18 +122,19 @@ namespace XJ {
     /**
      Get the choice of a given type
 
-     @param type of choice to get
+     @param segment for which to get choice
+     @param programType of choice to get
      @return choice of given type
      */
-    virtual std::optional<SegmentChoice *> getPreviousChoiceOfType(const Segment *segment, Program::Type type);
+    virtual std::optional<SegmentChoice *> getPreviousChoiceOfType(const Segment *segment, Program::Type programType);
 
     /**
      Get the previous-segment choice of a given type
 
-     @param type of choice to get
+     @param programType of choice to get
      @return choice of given type
      */
-    virtual std::optional<SegmentChoice *> getPreviousChoiceOfType(Program::Type type);
+    virtual std::optional<SegmentChoice *> getPreviousChoiceOfType(Program::Type programType);
 
     /**
      Get the previous-segment choices of a given instrument mode

--- a/engine/include/xjmusic/meme/MemeIsometry.h
+++ b/engine/include/xjmusic/meme/MemeIsometry.h
@@ -92,7 +92,7 @@ namespace XJ {
      * @param memes  The list of memes to check
      * @return       True if the list is allowed
      */
-    bool isAllowed(const std::set<std::string>& memes);
+    bool isAllowed(const std::set<std::string>& memes) const;
 
     /**
      Get the source Memes

--- a/engine/include/xjmusic/meme/MemeIsometry.h
+++ b/engine/include/xjmusic/meme/MemeIsometry.h
@@ -4,16 +4,14 @@
 #define XJMUSIC_ENTITIES_MEME_ISOMETRY_H
 
 #include <string>
-#include <utility>
 
+#include "xjmusic/content/InstrumentMeme.h"
 #include "xjmusic/content/ProgramMeme.h"
 #include "xjmusic/content/ProgramSequenceBindingMeme.h"
-#include "xjmusic/content/InstrumentMeme.h"
 #include "xjmusic/segment/SegmentMeme.h"
 
-#include "MemeTaxonomy.h"
 #include "MemeStack.h"
-#include "MemeConstellation.h"
+#include "MemeTaxonomy.h"
 
 namespace XJ {
 
@@ -22,13 +20,13 @@ namespace XJ {
    */
   class MemeIsometry {
   public:
-
     /**
      Construct a meme isometry from source memes
 
+     @param taxonomy    context within which to measure isometry
      @param sourceMemes from which to construct isometry
      */
-    explicit MemeIsometry(MemeTaxonomy taxonomy, const std::set<std::string>& sourceMemes);
+    explicit MemeIsometry(MemeTaxonomy taxonomy, const std::set<std::string> &sourceMemes);
 
     /**
      Instantiate a new MemeIsometry of a Taxonomy and group of source Memes
@@ -37,7 +35,7 @@ namespace XJ {
      @param sourceMemes to compare of
      @return MemeIsometry ready for comparison to target Memes
      */
-    static MemeIsometry of(MemeTaxonomy taxonomy, const std::set<std::string>& sourceMemes);
+    static MemeIsometry of(MemeTaxonomy taxonomy, const std::set<std::string> &sourceMemes);
 
     /**
      Instantiate a new MemeIsometry of a group of source Memes
@@ -60,39 +58,39 @@ namespace XJ {
      @param targets comma-separated values to score against source meme names
      @return score is between 0 (no matches) and the number of matching memes
      */
-    int score(const std::set<std::string>& targets);
+    int score(const std::set<std::string> &targets) const;
 
     /**
      Add a meme for isometry comparison
      */
-    void add(const std::string& meme);
+    void add(const std::string &meme);
 
     /**
      Add a program meme for isometry comparison
      */
-    void add(const ProgramMeme& meme);
+    void add(const ProgramMeme &meme);
 
     /**
      Add a program sequence binding meme for isometry comparison
      */
-    void add(const ProgramSequenceBindingMeme& meme);
+    void add(const ProgramSequenceBindingMeme &meme);
 
     /**
      Add a instrument meme for isometry comparison
      */
-    void add(const InstrumentMeme& meme);
+    void add(const InstrumentMeme &meme);
 
     /**
      Add a segment meme for isometry comparison
      */
-    void add(const SegmentMeme& meme);
+    void add(const SegmentMeme &meme);
 
     /**
      * Whether a list of memes is allowed because no more than one matches the category's memes
      * @param memes  The list of memes to check
      * @return       True if the list is allowed
      */
-    bool isAllowed(const std::set<std::string>& memes) const;
+    bool isAllowed(const std::set<std::string> &memes) const;
 
     /**
      Get the source Memes
@@ -117,6 +115,6 @@ namespace XJ {
     std::set<std::string> sources;
   };
 
-} // namespace XJ
+}// namespace XJ
 
 #endif//XJMUSIC_ENTITIES_MEME_ISOMETRY_H

--- a/engine/include/xjmusic/meme/MemeIsometry.h
+++ b/engine/include/xjmusic/meme/MemeIsometry.h
@@ -107,7 +107,7 @@ namespace XJ {
 
      @return unique constellation for this set of strings.
      */
-    std::string getConstellation();
+    std::string getConstellation() const;
 
   private:
     static const std::string KEY_NAME;

--- a/engine/include/xjmusic/meme/MemeTaxonomy.h
+++ b/engine/include/xjmusic/meme/MemeTaxonomy.h
@@ -161,7 +161,7 @@ namespace XJ {
      * Convert the taxonomy to a list of maps like [{name: "CATEGORY1", memes: ["MEME1", "MEME2"]}, {name: "CATEGORY2", memes: ["MEME3", "MEME4"]}]
      * @return  The list of maps
      */
-    std::set<MapStringToOneOrManyString> toList();
+    std::set<MapStringToOneOrManyString> toList() const;
 
     /**
      * Get the categories

--- a/engine/include/xjmusic/meme/MemeTaxonomy.h
+++ b/engine/include/xjmusic/meme/MemeTaxonomy.h
@@ -127,7 +127,7 @@ namespace XJ {
      * Construct a taxonomy from a list of maps like [{name: "CATEGORY1", memes: ["MEME1", "MEME2"]}, {name: "CATEGORY2", memes: ["MEME3", "MEME4"]}]
      * @param data  The list of maps
      */
-    explicit MemeTaxonomy(std::set<MapStringToOneOrManyString> &data);
+    explicit MemeTaxonomy(const std::set<MapStringToOneOrManyString> &data);
 
     /**
      * Construct an empty taxonomy

--- a/engine/include/xjmusic/meme/ParseAnti.h
+++ b/engine/include/xjmusic/meme/ParseAnti.h
@@ -24,7 +24,7 @@ namespace XJ {
     explicit ParseAnti(const std::string& raw);
     static ParseAnti fromString(const std::string& raw);
     [[nodiscard]] bool isViolatedBy(const ParseAnti &target) const;
-    bool isAllowed(const std::vector<ParseAnti> &memes);
+    bool isAllowed(const std::vector<ParseAnti> &memes) const;
   };
 }
 

--- a/engine/include/xjmusic/meme/ParseNumeric.h
+++ b/engine/include/xjmusic/meme/ParseNumeric.h
@@ -25,7 +25,7 @@ namespace XJ {
     explicit ParseNumeric(const std::string &raw);
     static ParseNumeric fromString(const std::string &raw);
     [[nodiscard]] bool isViolatedBy(const ParseNumeric &target) const;
-    bool isAllowed(const std::vector<ParseNumeric> &memes);
+    bool isAllowed(const std::vector<ParseNumeric> &memes) const;
   };
 
 

--- a/engine/include/xjmusic/meme/ParseStrong.h
+++ b/engine/include/xjmusic/meme/ParseStrong.h
@@ -6,7 +6,6 @@
 #include <regex>
 #include <vector>
 #include <string>
-#include <set>
 
 namespace XJ {
 

--- a/engine/include/xjmusic/meme/ParseStrong.h
+++ b/engine/include/xjmusic/meme/ParseStrong.h
@@ -24,7 +24,7 @@ namespace XJ {
     bool valid;
     explicit ParseStrong(const std::string &raw);
     static ParseStrong fromString(const std::string &raw);
-    bool isAllowed(const std::vector<ParseStrong> &memes);
+    bool isAllowed(const std::vector<ParseStrong> &memes) const;
   };
 
 }

--- a/engine/include/xjmusic/meme/ParseUnique.h
+++ b/engine/include/xjmusic/meme/ParseUnique.h
@@ -4,9 +4,8 @@
 #define XJMUSIC_ENTITIES_MEME_PARSE_UNIQUE_H
 
 #include <regex>
-#include <vector>
 #include <string>
-#include <set>
+#include <vector>
 
 
 namespace XJ {

--- a/engine/include/xjmusic/meme/ParseUnique.h
+++ b/engine/include/xjmusic/meme/ParseUnique.h
@@ -26,7 +26,7 @@ namespace XJ {
     explicit ParseUnique(const std::string &raw);
     static ParseUnique fromString(const std::string &raw);
     [[nodiscard]] bool isViolatedBy(const ParseUnique &target) const;
-    bool isAllowed(const std::vector<ParseUnique> &memes);
+    bool isAllowed(const std::vector<ParseUnique> &memes) const;
   };
 
 }//namespace XJ

--- a/engine/include/xjmusic/music/Bar.h
+++ b/engine/include/xjmusic/music/Bar.h
@@ -28,10 +28,10 @@ namespace XJ {
 
     /**
      * Compute the number of beats in a subsection of this Bar
-     * @param beats  number of beats in the subsection
+     * @param subBeats  number of beats in the subsection
      * @return       number of beats in the subsection
      */
-    [[nodiscard]] int computeSubsectionBeats(int beats) const;
+    [[nodiscard]] int computeSubsectionBeats(int subBeats) const;
   };
 
 }// namespace XJ

--- a/engine/include/xjmusic/music/Note.h
+++ b/engine/include/xjmusic/music/Note.h
@@ -211,7 +211,7 @@ namespace XJ {
      * @param target pitch class to seek
      * @return first note with given pitch class up from this
      */
-    Note nextUp(PitchClass target);
+    Note nextUp(PitchClass target) const;
 
     /**
      * Get the first occurrence of the given pitch class down from the current note

--- a/engine/include/xjmusic/music/Note.h
+++ b/engine/include/xjmusic/music/Note.h
@@ -8,7 +8,6 @@
 #include <string>
 
 #include "PitchClass.h"
-#include "Step.h"
 
 namespace XJ {
 
@@ -229,7 +228,7 @@ namespace XJ {
      * @param delta  direction (1 or -1) in which to seek
      * @return first note with given pitch class from this
      */
-    Note next(PitchClass target, int delta);
+    Note next(PitchClass target, int delta) const;
   };
 
 }// namespace XJ

--- a/engine/include/xjmusic/music/Note.h
+++ b/engine/include/xjmusic/music/Note.h
@@ -219,7 +219,7 @@ namespace XJ {
      * @param target pitch class to seek
      * @return first note with given pitch class down from this
      */
-    Note nextDown(PitchClass target);
+    Note nextDown(PitchClass target) const;
 
     /**
      * Get the first occurrence of the given pitch class in the given direction from the current note

--- a/engine/include/xjmusic/music/StickyBun.h
+++ b/engine/include/xjmusic/music/StickyBun.h
@@ -72,9 +72,10 @@ namespace XJ {
      * Replace atonal notes in the list with selections based on the sticky bun
      *
      * @param voicingNotes from which to select replacements
+     * @param index        of the note to replace
      * @return notes with atonal elements augmented by sticky bun
      */
-    [[nodiscard]] Note compute(std::vector<Note> voicingNotes, int index) const;
+    [[nodiscard]] Note compute(const std::vector<Note> &voicingNotes, int index) const;
 
     /**
      * Compute a meta key based on the event id

--- a/engine/include/xjmusic/segment/SegmentEntityStore.h
+++ b/engine/include/xjmusic/segment/SegmentEntityStore.h
@@ -77,7 +77,7 @@ namespace XJ {
      * Put the Chain in the entity store
      * @returns stored Chain
      */
-    Chain * put(const Chain &c);
+    Chain * put(const Chain &chain);
 
     /**
      * Put a Segment in the entity store

--- a/engine/include/xjmusic/util/ConfigParser.h
+++ b/engine/include/xjmusic/util/ConfigParser.h
@@ -107,7 +107,7 @@ namespace XJ {
    * Get the object as a map of strings to strings
    * @return  The object as a map of strings to strings
    */
-    std::map<std::string, std::variant<std::string, std::vector<std::string>>> asMapOfStringsOrListsOfStrings();
+    std::map<std::string, std::variant<std::string, std::vector<std::string>>> asMapOfStringsOrListsOfStrings() const;
   };
 
   /**
@@ -122,7 +122,7 @@ namespace XJ {
    * Get the size of the list
    * @return  The size of the list
    */
-    unsigned long size();
+    unsigned long size() const;
 
     /**
    * Get the list as a vector of strings

--- a/engine/include/xjmusic/util/ConfigParser.h
+++ b/engine/include/xjmusic/util/ConfigParser.h
@@ -59,7 +59,7 @@ namespace XJ {
      * Get a bool value from a ConfigSingleValue
      * @return           The bool value
      */
-    bool getBool();
+    bool getBool() const;
   };
 
   /**

--- a/engine/include/xjmusic/util/ConfigParser.h
+++ b/engine/include/xjmusic/util/ConfigParser.h
@@ -74,7 +74,7 @@ namespace XJ {
    * Get the size of the object
    * @return  The size of the object
    */
-    unsigned long size();
+    unsigned long size() const;
 
     /**
    * Get a single value from the object

--- a/engine/src/content/ContentEntityStore.cpp
+++ b/engine/src/content/ContentEntityStore.cpp
@@ -1037,45 +1037,45 @@ ContentEntityStore ContentEntityStore::forTemplate(const Template *tmpl) {
   }
 
   // Add entities of Programs
-  for (const auto &program: content.programs) {
-    for (const auto meme: getMemesOfProgram(program.second.id)) {
+  for (const auto &[_, program]: content.programs) {
+    for (const auto meme: getMemesOfProgram(program.id)) {
       content.programMemes[meme->id] = *meme;
     }
-    for (const auto voice: getVoicesOfProgram(program.second.id)) {
+    for (const auto voice: getVoicesOfProgram(program.id)) {
       content.programVoices[voice->id] = *voice;
     }
-    for (const auto track: getTracksOfProgram(program.second.id)) {
+    for (const auto track: getTracksOfProgram(program.id)) {
       content.programVoiceTracks[track->id] = *track;
     }
-    for (const auto sequence: getSequencesOfProgram(program.second.id)) {
+    for (const auto sequence: getSequencesOfProgram(program.id)) {
       content.programSequences[sequence->id] = *sequence;
     }
-    for (const ProgramSequenceBinding *binding: getSequenceBindingsOfProgram(program.second.id)) {
+    for (const ProgramSequenceBinding *binding: getSequenceBindingsOfProgram(program.id)) {
       content.programSequenceBindings[binding->id] = *binding;
     }
-    for (const auto meme: getSequenceBindingMemesOfProgram(program.second.id)) {
+    for (const auto meme: getSequenceBindingMemesOfProgram(program.id)) {
       content.programSequenceBindingMemes[meme->id] = *meme;
     }
-    for (const ProgramSequenceChord *chord: getSequenceChordsOfProgram(program.second.id)) {
+    for (const ProgramSequenceChord *chord: getSequenceChordsOfProgram(program.id)) {
       content.programSequenceChords[chord->id] = *chord;
     }
-    for (const auto voicing: getSequenceChordVoicingsOfProgram(program.second.id)) {
+    for (const auto voicing: getSequenceChordVoicingsOfProgram(program.id)) {
       content.programSequenceChordVoicings[voicing->id] = *voicing;
     }
-    for (const auto pattern: getSequencePatternsOfProgram(program.second.id)) {
+    for (const auto pattern: getSequencePatternsOfProgram(program.id)) {
       content.programSequencePatterns[pattern->id] = *pattern;
     }
-    for (const ProgramSequencePatternEvent *event: getSequencePatternEventsOfProgram(program.second.id)) {
+    for (const ProgramSequencePatternEvent *event: getSequencePatternEventsOfProgram(program.id)) {
       content.programSequencePatternEvents[event->id] = *event;
     }
   }
 
   // Add entities of Instruments
-  for (const auto &instrument: content.instruments) {
-    for (const auto meme: getMemesOfInstrument(instrument.second.id)) {
+  for (const auto &[_, instrument]: content.instruments) {
+    for (const auto meme: getMemesOfInstrument(instrument.id)) {
       content.instrumentMemes[meme->id] = *meme;
     }
-    for (const auto audio: getAudiosOfInstrument(instrument.second.id)) {
+    for (const auto audio: getAudiosOfInstrument(instrument.id)) {
       content.instrumentAudios[audio->id] = *audio;
     }
   }

--- a/engine/src/content/Instrument.cpp
+++ b/engine/src/content/Instrument.cpp
@@ -40,7 +40,7 @@ static const std::map<std::string, Instrument::State> stateNameValues = EntityUt
 
 Instrument::Type Instrument::parseType(const std::string &value) {
   if (typeNameValues.count(value) == 0) {
-    return Instrument::Type::Drum;
+    return Drum;
   }
   return typeNameValues.at(value);
 }
@@ -48,7 +48,7 @@ Instrument::Type Instrument::parseType(const std::string &value) {
 
 Instrument::Mode Instrument::parseMode(const std::string &value) {
   if (modeNameValues.count(value) == 0) {
-    return Instrument::Mode::Event;
+    return Event;
   }
   return modeNameValues.at(value);
 }
@@ -56,27 +56,27 @@ Instrument::Mode Instrument::parseMode(const std::string &value) {
 
 Instrument::State Instrument::parseState(const std::string &value) {
   if (stateNameValues.count(value) == 0) {
-    return Instrument::State::Draft;
+    return Draft;
   }
   return stateNameValues.at(value);
 }
 
 
-std::string Instrument::toString(const Instrument::Type &type) {
+std::string Instrument::toString(const Type &type) {
   return typeValueNames.at(type);
 }
 
 
-std::string Instrument::toString(const Instrument::Mode &mode) {
+std::string Instrument::toString(const Mode &mode) {
   return modeValueNames.at(mode);
 }
 
 
-std::string Instrument::toString(const Instrument::State &state) {
+std::string Instrument::toString(const State &state) {
   return stateValueNames.at(state);
 }
 
-const std::vector<std::string> &Instrument::toStrings(std::vector<Instrument::Type> types) {
+const std::vector<std::string> &Instrument::toStrings(std::vector<Type> types) {
   static std::vector<std::string> typeStrings;
   typeStrings.clear();
   for (const auto &type : types) {

--- a/engine/src/content/InstrumentConfig.cpp
+++ b/engine/src/content/InstrumentConfig.cpp
@@ -64,8 +64,8 @@ std::string InstrumentConfig::toString() const {
   std::sort(configVec.begin(), configVec.end());
 
   std::ostringstream oss;
-  for (const auto &pair: configVec) {
-    oss << pair.first << " = " << pair.second << "\n";
+  for (const auto &[key, val]: configVec) {
+    oss << key << " = " << val << "\n";
   }
 
   return oss.str();

--- a/engine/src/content/InstrumentConfig.cpp
+++ b/engine/src/content/InstrumentConfig.cpp
@@ -49,13 +49,13 @@ InstrumentConfig::InstrumentConfig(const std::string &input) : ConfigParser(inpu
 
 std::string InstrumentConfig::toString() const {
   std::map<std::string, std::string> config;
-  config["isAudioSelectionPersistent"] = ConfigParser::format(isAudioSelectionPersistent);
-  config["isMultiphonic"] = ConfigParser::format(isMultiphonic);
-  config["isOneShot"] = ConfigParser::format(isOneShot);
-  config["isOneShotCutoffEnabled"] = ConfigParser::format(isOneShotCutoffEnabled);
-  config["isTonal"] = ConfigParser::format(isTonal);
+  config["isAudioSelectionPersistent"] = format(isAudioSelectionPersistent);
+  config["isMultiphonic"] = format(isMultiphonic);
+  config["isOneShot"] = format(isOneShot);
+  config["isOneShotCutoffEnabled"] = format(isOneShotCutoffEnabled);
+  config["isTonal"] = format(isTonal);
   config["releaseMillis"] = std::to_string(releaseMillis);
-  config["oneShotObserveLengthOfEvents"] = ConfigParser::format(oneShotObserveLengthOfEvents);
+  config["oneShotObserveLengthOfEvents"] = format(oneShotObserveLengthOfEvents);
 
   // Convert the map to a vector of pairs for sorting
   std::vector<std::pair<std::string, std::string>> configVec(config.begin(), config.end());

--- a/engine/src/content/Program.cpp
+++ b/engine/src/content/Program.cpp
@@ -29,7 +29,7 @@ static const std::map<std::string, Program::State> stateNameValues = EntityUtils
 
 Program::Type Program::parseType(const std::string &value) {
   if (typeNameValues.count(value) == 0) {
-    return Program::Type::Main;
+    return Main;
   }
   return typeNameValues.at(value);
 }
@@ -37,17 +37,17 @@ Program::Type Program::parseType(const std::string &value) {
 
 Program::State Program::parseState(const std::string &value) {
   if (stateNameValues.count(value) == 0) {
-    return Program::State::Draft;
+    return Draft;
   }
   return stateNameValues.at(value);
 }
 
 
-std::string Program::toString(const Program::Type &type) {
+std::string Program::toString(const Type &type) {
   return typeValueNames.at(type);
 }
 
 
-std::string Program::toString(const Program::State &state) {
+std::string Program::toString(const State &state) {
   return stateValueNames.at(state);
 }

--- a/engine/src/content/ProgramConfig.cpp
+++ b/engine/src/content/ProgramConfig.cpp
@@ -42,8 +42,8 @@ std::string ProgramConfig::toString() const {
   std::sort(configVec.begin(), configVec.end());
 
   std::ostringstream oss;
-  for (const auto &pair: configVec) {
-    oss << pair.first << " = " << pair.second << "\n";
+  for (const auto &[key, val]: configVec) {
+    oss << key << " = " << val << "\n";
   }
 
   return oss.str();

--- a/engine/src/content/ProgramVoice.cpp
+++ b/engine/src/content/ProgramVoice.cpp
@@ -3,9 +3,9 @@
 #include <set>
 #include "xjmusic/content/ProgramVoice.h"
 
-std::set<std::string> XJ::ProgramVoice::getNames(const std::set<const XJ::ProgramVoice *>& voices) {
+std::set<std::string> XJ::ProgramVoice::getNames(const std::set<const ProgramVoice *>& voices) {
   std::set<std::string> names;
-  for (const XJ::ProgramVoice *voice : voices) {
+  for (const ProgramVoice *voice : voices) {
     names.insert(voice->name);
   }
   return names;

--- a/engine/src/content/TemplateBinding.cpp
+++ b/engine/src/content/TemplateBinding.cpp
@@ -26,13 +26,13 @@ std::string TemplateBinding::toString() const {
 
 TemplateBinding::Type TemplateBinding::parseType(const std::string &value) {
   if (typeNameValues.count(value) == 0) {
-    return TemplateBinding::Type::Library;
+    return Library;
   }
   return typeNameValues.at(value);
 }
 
 
-std::string TemplateBinding::toString(const TemplateBinding::Type &type) {
+std::string TemplateBinding::toString(const Type &type) {
   return typeValueNames.at(type);
 }
 

--- a/engine/src/content/TemplateConfig.cpp
+++ b/engine/src/content/TemplateConfig.cpp
@@ -324,32 +324,32 @@ bool TemplateConfig::instrumentTypesForInversionSeekingContains(const Instrument
 float TemplateConfig::getChoiceMuteProbability(const Instrument::Type type) {
   if (choiceMuteProbability.find(type) != choiceMuteProbability.end()) {
     return choiceMuteProbability[type];
-  } else {
-    return 0.0f;
   }
+
+  return 0.0f;
 }
 
 float TemplateConfig::getDubMasterVolume(const Instrument::Type type) {
   if (dubMasterVolume.find(type) != dubMasterVolume.end()) {
     return dubMasterVolume[type];
-  } else {
-    return 0.0f;
   }
+
+  return 0.0f;
 }
 
 float TemplateConfig::getIntensityThreshold(const Instrument::Type type) {
   if (intensityThreshold.find(type) != intensityThreshold.end()) {
     return intensityThreshold[type];
-  } else {
-    return 0.0f;
   }
+
+  return 0.0f;
 }
 
 int TemplateConfig::getIntensityLayers(const Instrument::Type type) {
   if (intensityLayers.find(type) != intensityLayers.end()) {
     return intensityLayers[type];
-  } else {
-    return 0;
   }
+
+  return 0;
 }
 

--- a/engine/src/content/TemplateConfig.cpp
+++ b/engine/src/content/TemplateConfig.cpp
@@ -126,7 +126,7 @@ std::map<Instrument::Type, float> parseInstrumentTypeFloatMap(ConfigObjectValue 
 }
 
 
-std::vector<Instrument::Type> parseInstrumentTypeList(ConfigListValue listValue) {
+std::vector<Instrument::Type> parseInstrumentTypeList(const ConfigListValue &listValue) {
   std::vector<Instrument::Type> result;
   result.reserve(listValue.size());
   for (const auto &value: listValue.asListOfStrings()) {
@@ -224,7 +224,7 @@ std::string TemplateConfig::formatInstrumentTypeList(const std::vector<Instrumen
 
 
 std::string TemplateConfig::formatInstrumentTypeList(const std::set<Instrument::Type> &input) {
-  std::vector<Instrument::Type> sorted(input.begin(), input.end());
+  std::vector sorted(input.begin(), input.end());
   std::sort(sorted.begin(), sorted.end());
   return formatInstrumentTypeList(sorted);
 }

--- a/engine/src/content/TemplateConfig.cpp
+++ b/engine/src/content/TemplateConfig.cpp
@@ -104,10 +104,10 @@ TemplateConfig::TemplateConfig(const Template *input) : TemplateConfig(input->co
 
 std::map<Instrument::Type, int> parseInstrumentTypeIntMap(ConfigObjectValue objectValue) {
   std::map<Instrument::Type, int> resultMap;
-  for (const auto &entry: objectValue.asMapOfSingleOrList()) {
-    Instrument::Type instrumentTypeKey = Instrument::parseType(entry.first);
-    if (std::holds_alternative<ConfigSingleValue>(entry.second)) {
-      resultMap[instrumentTypeKey] = std::get<ConfigSingleValue>(entry.second).getInt();
+  for (const auto &[key, val]: objectValue.asMapOfSingleOrList()) {
+    Instrument::Type instrumentTypeKey = Instrument::parseType(key);
+    if (std::holds_alternative<ConfigSingleValue>(val)) {
+      resultMap[instrumentTypeKey] = std::get<ConfigSingleValue>(val).getInt();
     }
   }
   return resultMap;
@@ -116,10 +116,10 @@ std::map<Instrument::Type, int> parseInstrumentTypeIntMap(ConfigObjectValue obje
 
 std::map<Instrument::Type, float> parseInstrumentTypeFloatMap(ConfigObjectValue objectValue) {
   std::map<Instrument::Type, float> resultMap;
-  for (const auto &entry: objectValue.asMapOfSingleOrList()) {
-    Instrument::Type instrumentTypeKey = Instrument::parseType(entry.first);
-    if (std::holds_alternative<ConfigSingleValue>(entry.second)) {
-      resultMap[instrumentTypeKey] = std::get<ConfigSingleValue>(entry.second).getFloat();
+  for (const auto &[key, val]: objectValue.asMapOfSingleOrList()) {
+    Instrument::Type instrumentTypeKey = Instrument::parseType(key);
+    if (std::holds_alternative<ConfigSingleValue>(val)) {
+      resultMap[instrumentTypeKey] = std::get<ConfigSingleValue>(val).getFloat();
     }
   }
   return resultMap;
@@ -149,8 +149,8 @@ std::string formatInstrumentTypeIntMap(const std::map<Instrument::Type, int> &va
   // Convert the map to a vector of pairs for sorting
   std::vector<std::pair<std::string, int>> valuesVec;
   valuesVec.reserve(values.size());
-  for (const auto &entry: values) {
-    valuesVec.emplace_back(Instrument::toString(entry.first), entry.second);
+  for (const auto &[key, val]: values) {
+    valuesVec.emplace_back(Instrument::toString(key), val);
   }
 
   // Sort the vector by key
@@ -158,8 +158,8 @@ std::string formatInstrumentTypeIntMap(const std::map<Instrument::Type, int> &va
 
   std::ostringstream oss;
   oss << "{\n";
-  for (const auto &entry: valuesVec) {
-    oss << "    " << entry.first << " = " << std::to_string(entry.second) << "\n";
+  for (const auto &[key, val]: valuesVec) {
+    oss << "    " << key << " = " << std::to_string(val) << "\n";
   }
   oss << "  }";
   return oss.str();
@@ -170,8 +170,8 @@ std::string formatInstrumentTypeFloatMap(const std::map<Instrument::Type, float>
   // Convert the map to a vector of pairs for sorting
   std::vector<std::pair<std::string, float>> valuesVec;
   valuesVec.reserve(values.size());
-  for (const auto &entry: values) {
-    valuesVec.emplace_back(Instrument::toString(entry.first), entry.second);
+  for (const auto &[key, val]: values) {
+    valuesVec.emplace_back(Instrument::toString(key), val);
   }
 
   // Sort the vector by key
@@ -179,8 +179,8 @@ std::string formatInstrumentTypeFloatMap(const std::map<Instrument::Type, float>
 
   std::ostringstream oss;
   oss << "{\n";
-  for (const auto &entry: valuesVec) {
-    oss << "    " << entry.first << " = " << StringUtils::formatFloat(entry.second) << "\n";
+  for (const auto &[key, val]: valuesVec) {
+    oss << "    " << key << " = " << StringUtils::formatFloat(val) << "\n";
   }
   oss << "  }";
   return oss.str();
@@ -308,8 +308,8 @@ std::string TemplateConfig::toString() const {
   std::sort(configVec.begin(), configVec.end());
 
   std::ostringstream oss;
-  for (const auto &pair: configVec) {
-    oss << pair.first << " = " << pair.second << "\n";
+  for (const auto &[key, val]: configVec) {
+    oss << key << " = " << val << "\n";
   }
 
   return oss.str();

--- a/engine/src/craft/BackgroundCraft.cpp
+++ b/engine/src/craft/BackgroundCraft.cpp
@@ -22,7 +22,7 @@ void BackgroundCraft::doWork() {
   craftBackground(instrument.value());
 }
 
-void BackgroundCraft::craftBackground(const Instrument *instrument) {
+void BackgroundCraft::craftBackground(const Instrument *instrument) const {
   auto choice = SegmentChoice();
   choice.id = EntityUtils::computeUniqueId();
   choice.segmentId = fabricator->getSegment()->id;

--- a/engine/src/craft/BackgroundCraft.cpp
+++ b/engine/src/craft/BackgroundCraft.cpp
@@ -8,7 +8,7 @@ BackgroundCraft::BackgroundCraft(
     Fabricator *fabricator
 ) : Craft(fabricator) {}
 
-void BackgroundCraft::doWork() {
+void BackgroundCraft::doWork() const {
   const auto previousChoice = fabricator->getRetrospective()->getPreviousChoiceOfType(Instrument::Type::Background);
 
   const auto instrument = previousChoice.has_value() ?

--- a/engine/src/craft/BeatCraft.cpp
+++ b/engine/src/craft/BeatCraft.cpp
@@ -30,13 +30,13 @@ void BeatCraft::doWork() {
         return "unknown";
       });
 
-  std::function<bool(const SegmentChoice *)> choiceFilter = [](const SegmentChoice *choice) {
+  std::function choiceFilter = [](const SegmentChoice *choice) {
     return Program::Type::Beat == choice->programType;
   };
 
   auto programVoices = fabricator->getSourceMaterial()->getVoicesOfProgram(program.value());
   auto voiceNames = ProgramVoice::getNames(programVoices);
-  auto voiceNameVector = std::vector<std::string>(voiceNames.begin(), voiceNames.end());
+  auto voiceNameVector = std::vector(voiceNames.begin(), voiceNames.end());
 
   precomputeDeltas(
       choiceFilter,

--- a/engine/src/craft/BeatCraft.cpp
+++ b/engine/src/craft/BeatCraft.cpp
@@ -23,7 +23,7 @@ void BeatCraft::doWork() {
   }
 
   // Segments have intensity arcs; automate mixer layers in and out of each main program https://github.com/xjmusic/xjmusic/issues/233
-  Craft::ChoiceIndexProvider *choiceIndexProvider = new Craft::LambdaChoiceIndexProvider(
+  ChoiceIndexProvider *choiceIndexProvider = new LambdaChoiceIndexProvider(
       [this](const SegmentChoice &choice) -> std::string {
         const auto voice = fabricator->getSourceMaterial()->getProgramVoice(choice.programVoiceId);
         if (voice.has_value()) return voice.value()->name;

--- a/engine/src/craft/Craft.cpp
+++ b/engine/src/craft/Craft.cpp
@@ -24,13 +24,13 @@ bool Craft::isOutroSegment(const SegmentChoice *choice) const {
 }
 
 bool Craft::isSilentEntireSegment(const SegmentChoice *choice) const {
-  return (choice->deltaOut < fabricator->getSegment()->delta) ||
-         (choice->deltaIn >= fabricator->getSegment()->delta + fabricator->getSegment()->total);
+  return choice->deltaOut < fabricator->getSegment()->delta ||
+         choice->deltaIn >= fabricator->getSegment()->delta + fabricator->getSegment()->total;
 }
 
 bool Craft::isActiveEntireSegment(const SegmentChoice *choice) const {
-  return (choice->deltaIn <= fabricator->getSegment()->delta) &&
-         (choice->deltaOut >= fabricator->getSegment()->delta + fabricator->getSegment()->total);
+  return choice->deltaIn <= fabricator->getSegment()->delta &&
+         choice->deltaOut >= fabricator->getSegment()->delta + fabricator->getSegment()->total;
 }
 
 void Craft::craftNoteEventArrangements(const float tempo, const SegmentChoice *choice, const bool defaultAtonal) {
@@ -113,7 +113,7 @@ void Craft::precomputeDeltas(
       auto delta = ValueUtils::roundToNearest(deltaUnits, MarbleBag::quickPick(deltaUnits * 4) -
                                                               deltaUnits * 2 * numLayersIncoming);
       for (const std::string &orderedLayer: orderedLayers) {
-        deltaIns[orderedLayer] = (delta > 0) ? delta : SegmentChoice::DELTA_UNLIMITED;
+        deltaIns[orderedLayer] = delta > 0 ? delta : SegmentChoice::DELTA_UNLIMITED;
         deltaOuts[orderedLayer] = SegmentChoice::DELTA_UNLIMITED;// all layers get delta out unlimited
         delta += ValueUtils::roundToNearest(deltaUnits, MarbleBag::quickPick(deltaUnits * 5));
       }
@@ -594,12 +594,12 @@ void Craft::craftEventParts(const float tempo, const Instrument *instrument, con
 
 int Craft::computeDeltaIn(const SegmentChoice *choice) {
   const auto it = deltaIns.find(choiceIndexProvider->get(choice));
-  return (it != deltaIns.end()) ? it->second : SegmentChoice::DELTA_UNLIMITED;
+  return it != deltaIns.end() ? it->second : SegmentChoice::DELTA_UNLIMITED;
 }
 
 int Craft::computeDeltaOut(const SegmentChoice *choice) {
   const auto it = deltaOuts.find(choiceIndexProvider->get(choice));
-  return (it != deltaOuts.end()) ? it->second : SegmentChoice::DELTA_UNLIMITED;
+  return it != deltaOuts.end() ? it->second : SegmentChoice::DELTA_UNLIMITED;
 }
 
 void Craft::craftNoteEventSectionRestartingEachChord(
@@ -717,14 +717,14 @@ void Craft::pickNotesAndInstrumentAudioForEvent(
   const std::set<std::string> notes = chord.value() && voicing.has_value()
                                           ? pickNotesForEvent(instrument->type, choice, event, chord.value(),
                                                               voicing.value(), range)
-                                          : (defaultAtonal ? std::set<std::string>{"ATONAL"}
-                                                           : std::set<std::string>{});
+                                          : defaultAtonal ? std::set<std::string>{"ATONAL"}
+                                                      : std::set<std::string>{};
 
   // Pick attributes are expressed "rendered" as actual seconds
   const long startAtSegmentMicros = fabricator->getSegmentMicrosAtPosition(tempo, segmentPosition);
   const std::optional<long> lengthMicros = fabricator->isOneShot(instrument, fabricator->getTrackName(event))
                                                ? std::nullopt
-                                               : std::optional<long>(
+                                               : std::optional(
                                                      fabricator->getSegmentMicrosAtPosition(tempo, segmentPosition + duration) -
                                                      startAtSegmentMicros);
 

--- a/engine/src/craft/Craft.cpp
+++ b/engine/src/craft/Craft.cpp
@@ -41,7 +41,7 @@ void Craft::craftNoteEventArrangements(const float tempo, const SegmentChoice *c
   if (!fabricator->getProgram(choice).has_value())
     throw FabricationException("Can't get program config");
 
-  if (const auto programConfig = XJ::Fabricator::getProgramConfig(fabricator->getProgram(choice).value());
+  if (const auto programConfig = Fabricator::getProgramConfig(fabricator->getProgram(choice).value());
       fabricator->getSegmentChords().empty() || !programConfig.doPatternRestartOnChord) {
     craftNoteEventSection(tempo, choice, 0, static_cast<float>(fabricator->getSegment()->total), &range, defaultAtonal);
   } else {
@@ -922,10 +922,9 @@ Craft::selectMultiphonicInstrumentAudio(
       }
     }
     return fabricator->getPreferredAudio(event->programVoiceTrackId, note);
-
-  } else {
-    return selectNewMultiphonicInstrumentAudio(instrument, note);
   }
+
+  return selectNewMultiphonicInstrumentAudio(instrument, note);
 }
 
 std::optional<const InstrumentAudio *>
@@ -937,10 +936,9 @@ Craft::selectMonophonicInstrumentAudio(const Instrument *instrument, const Progr
       fabricator->putPreferredAudio(event->programVoiceTrackId, event->tones, selection.value());
     }
     return fabricator->getPreferredAudio(event->programVoiceTrackId, event->tones);
-
-  } else {
-    return selectNewNoteEventInstrumentAudio(instrument, event);
   }
+
+  return selectNewNoteEventInstrumentAudio(instrument, event);
 }
 
 std::optional<const InstrumentAudio *>
@@ -954,10 +952,9 @@ Craft::selectChordPartInstrumentAudio(const Instrument *instrument, const Chord 
       }
     }
     return fabricator->getPreferredAudio(instrument->id, chord.getName());
-
-  } else {
-    return selectNewChordPartInstrumentAudio(instrument, chord);
   }
+
+  return selectNewChordPartInstrumentAudio(instrument, chord);
 }
 
 std::optional<const InstrumentAudio *>
@@ -1003,7 +1000,7 @@ Craft::selectNewMultiphonicInstrumentAudio(const Instrument *instrument, std::st
     std::sort(availableNotes.begin(), availableNotes.end());
     std::vector<std::string> availableNoteNames;
     for (auto N: availableNotes) {
-      availableNoteNames.push_back(N.toString(Accidental::Sharp));
+      availableNoteNames.push_back(N.toString(Sharp));
     }
     const std::map<std::string, std::string> reportMissingData = {
         {"instrumentId", instrument->id},

--- a/engine/src/craft/Craft.cpp
+++ b/engine/src/craft/Craft.cpp
@@ -166,7 +166,7 @@ Craft::chooseFreshProgram(const Program::Type programType, const std::optional<I
   }
 
   // (3) score each source program based on meme isometry
-  MemeIsometry iso = fabricator->getMemeIsometryOfSegment();
+  const MemeIsometry iso = fabricator->getMemeIsometryOfSegment();
   std::set<std::string> memes;
 
   // Phase 1: Directly Bound Programs
@@ -206,7 +206,7 @@ Craft::chooseFreshInstrument(const Instrument::Type type, const std::set<std::st
   }
 
   // Retrieve meme isometry of segment
-  MemeIsometry iso = fabricator->getMemeIsometryOfSegment();
+  const MemeIsometry iso = fabricator->getMemeIsometryOfSegment();
   std::set<std::string> memes;
 
   // Phase 1: Directly Bound Instruments
@@ -246,7 +246,7 @@ Craft::chooseFreshInstrumentAudio(
   }
 
   // (3) score each source instrument based on meme isometry
-  MemeIsometry iso = fabricator->getMemeIsometryOfSegment();
+  const MemeIsometry iso = fabricator->getMemeIsometryOfSegment();
   std::set<std::string> memes;
 
   // Phase 1: Directly Bound Audios (Preferred)

--- a/engine/src/craft/DetailCraft.cpp
+++ b/engine/src/craft/DetailCraft.cpp
@@ -4,7 +4,7 @@
 
 using namespace XJ;
 
-static std::set<Instrument::Type> DETAIL_INSTRUMENT_TYPES = {
+static std::set DETAIL_INSTRUMENT_TYPES = {
     Instrument::Type::Bass,
     Instrument::Type::Pad,
     Instrument::Type::Sticky,

--- a/engine/src/craft/DetailCraft.cpp
+++ b/engine/src/craft/DetailCraft.cpp
@@ -19,14 +19,14 @@ DetailCraft::DetailCraft(
 
 void DetailCraft::doWork() {
   // Segments have delta arcs; automate mixer layers in and out of each main program https://github.com/xjmusic/xjmusic/issues/233
-  Craft::ChoiceIndexProvider *choiceIndexProvider = new Craft::LambdaChoiceIndexProvider(
+  ChoiceIndexProvider *choiceIndexProvider = new LambdaChoiceIndexProvider(
       [](const SegmentChoice &choice) -> std::string {
         auto typeString = Instrument::toString(choice.instrumentType);
         if (typeString.empty()) {
           return choice.id;
-        } else {
-          return typeString;
         }
+
+        return typeString;
       });
   const std::function choiceFilter = [](const SegmentChoice *choice) {
     return Program::Type::Detail == choice->programType;
@@ -56,7 +56,7 @@ void DetailCraft::doWork() {
     }
 
     // Instruments have Instrument::Mode https://github.com/xjmusic/xjmusic/issues/260
-    std::optional<const XJ::Program*> program;
+    std::optional<const Program*> program;
     switch (instrument.value()->mode) {
 
       // Event instrument mode takes over legacy behavior https://github.com/xjmusic/xjmusic/issues/234

--- a/engine/src/craft/MacroMainCraft.cpp
+++ b/engine/src/craft/MacroMainCraft.cpp
@@ -178,10 +178,10 @@ double MacroMainCraft::computeSegmentIntensity(
 float MacroMainCraft::computeIntensity(
     const std::optional<const ProgramSequence *> macroSequence,
     const std::optional<const ProgramSequence *> mainSequence) {
-  const std::optional<float> macroIntensity = macroSequence.has_value() ? std::optional<float>(
+  const std::optional<float> macroIntensity = macroSequence.has_value() ? std::optional(
                                                                               macroSequence.value()->intensity)
                                                                         : std::nullopt;
-  const std::optional<float> mainIntensity = mainSequence.has_value() ? std::optional<float>(mainSequence.value()->intensity)
+  const std::optional<float> mainIntensity = mainSequence.has_value() ? std::optional(mainSequence.value()->intensity)
                                                                 : std::nullopt;
   if (macroIntensity.has_value() && mainIntensity.has_value())
     return (macroIntensity.value() + mainIntensity.value()) / 2;
@@ -303,7 +303,7 @@ const Program *MacroMainCraft::chooseMacroProgram() const {
 
   // Compute any program id to avoid
   auto avoidOpt = fabricator->getMacroChoiceOfPreviousSegment();
-  auto avoidProgramId = avoidOpt.has_value() ? std::optional<std::string>(avoidOpt.value()->programId) : std::nullopt;
+  auto avoidProgramId = avoidOpt.has_value() ? std::optional(avoidOpt.value()->programId) : std::nullopt;
 
   // Add candidates to the bag
   // Phase 1: Directly Bound Programs besides any that should be avoided, with a meme match
@@ -374,7 +374,7 @@ const Program *MacroMainCraft::chooseMainProgram() const {
 
   // Compute any program id to avoid
   auto avoidChoice = fabricator->getPreviousMainChoice();
-  auto avoidProgramId = avoidChoice.has_value() ? std::optional<std::string>(avoidChoice.value()->programId)
+  auto avoidProgramId = avoidChoice.has_value() ? std::optional(avoidChoice.value()->programId)
                                                 : std::nullopt;
 
   // Add candidates to the bag

--- a/engine/src/craft/TransitionCraft.cpp
+++ b/engine/src/craft/TransitionCraft.cpp
@@ -14,7 +14,7 @@ TransitionCraft::TransitionCraft(
 }
 
 
-void TransitionCraft::doWork() {
+void TransitionCraft::doWork() const {
   const auto previousChoice =
       fabricator->getRetrospective()->getPreviousChoiceOfType(Instrument::Type::Transition);
 

--- a/engine/src/craft/TransitionCraft.cpp
+++ b/engine/src/craft/TransitionCraft.cpp
@@ -94,7 +94,7 @@ void TransitionCraft::craftTransition(double tempo, const Instrument* instrument
   }
 }
 
-std::set<const InstrumentAudio *> TransitionCraft::selectAudiosForInstrument(const Instrument *instrument, std::set<std::string> names) {
+std::set<const InstrumentAudio *> TransitionCraft::selectAudiosForInstrument(const Instrument *instrument, std::set<std::string> names) const {
   std::set<const SegmentChoiceArrangementPick*> previous;
   for (auto candidate : fabricator->getRetrospective()->getPreviousPicksForInstrument(instrument->id)) {
     std::string seek = StringUtils::toMeme(candidate->event);

--- a/engine/src/craft/TransitionCraft.cpp
+++ b/engine/src/craft/TransitionCraft.cpp
@@ -51,7 +51,7 @@ bool TransitionCraft::isMediumTransitionSegment() const {
   return mainSequence.value()->id != previousMainSequence.value()->id;
 }
 
-void TransitionCraft::craftTransition(double tempo, const Instrument* instrument) {
+void TransitionCraft::craftTransition(double tempo, const Instrument* instrument) const {
   auto choice = SegmentChoice();
   choice.id = EntityUtils::computeUniqueId();
   choice.segmentId = fabricator->getSegment()->id;

--- a/engine/src/fabricator/Fabricator.cpp
+++ b/engine/src/fabricator/Fabricator.cpp
@@ -8,9 +8,9 @@
 #include "xjmusic/fabricator/Fabricator.h"
 #include "xjmusic/fabricator/MarbleBag.h"
 #include "xjmusic/fabricator/SegmentUtils.h"
+#include "xjmusic/music/Step.h"
 #include "xjmusic/util/CsvUtils.h"
-
-#include <xjmusic/util/ValueUtils.h>
+#include "xjmusic/util/ValueUtils.h"
 
 using namespace XJ;
 

--- a/engine/src/fabricator/Fabricator.cpp
+++ b/engine/src/fabricator/Fabricator.cpp
@@ -726,7 +726,7 @@ Segment *Fabricator::getSegment() {
 
 std::vector<SegmentChord *> Fabricator::getSegmentChords() {
   auto chords = store->readAllSegmentChords(segmentId);
-  std::vector<SegmentChord *> sortedChords = std::vector<SegmentChord *>(chords.begin(), chords.end());
+  auto sortedChords = std::vector(chords.begin(), chords.end());
   std::sort(sortedChords.begin(), sortedChords.end(), [](const SegmentChord *a, const SegmentChord *b) {
     return a->position < b->position;
   });
@@ -1149,7 +1149,7 @@ bool Fabricator::isValidChoiceAndMemesHaveBeenAdded(const SegmentChoice &choice,
   if (!force && !memeStack.isAllowed(names)) {
     addMessage(SegmentMessage::Type::Error,
                "Refused to add Choice[" + SegmentUtils::describe(choice) + "] because adding Memes[" +
-                   CsvUtils::join(std::vector<std::string>(names.begin(), names.end())) + "] to MemeStack[" +
+                   CsvUtils::join(std::vector(names.begin(), names.end())) + "] to MemeStack[" +
                    memeStack.getConstellation() + "] would result in an invalid meme stack theorem!");
     return false;
   }

--- a/engine/src/fabricator/Fabricator.cpp
+++ b/engine/src/fabricator/Fabricator.cpp
@@ -245,11 +245,11 @@ std::optional<SegmentChoice *> Fabricator::getChoiceIfContinued(const Instrument
 
   if (it != choices.end()) {
     return *it;
-  } else {
-    spdlog::warn("[seg-{}] Could not get previous choice for instrumentType={}", segmentId,
-                 Instrument::toString(instrumentType));
-    return std::nullopt;
   }
+
+  spdlog::warn("[seg-{}] Could not get previous choice for instrumentType={}", segmentId,
+               Instrument::toString(instrumentType));
+  return std::nullopt;
 }
 
 
@@ -264,11 +264,11 @@ Fabricator::getChoiceIfContinued(const Instrument::Type instrumentType, const In
 
   if (it != choices.end()) {
     return *it;
-  } else {
-    spdlog::warn("[seg-{}] Could not get previous choice for instrumentType={}", segmentId,
-                 Instrument::toString(instrumentType));
-    return std::nullopt;
   }
+
+  spdlog::warn("[seg-{}] Could not get previous choice for instrumentType={}", segmentId,
+               Instrument::toString(instrumentType));
+  return std::nullopt;
 }
 
 
@@ -514,8 +514,8 @@ NoteRange Fabricator::getProgramRange(const UUID &programId, const Instrument::T
 
 int Fabricator::getProgramRangeShiftOctaves(const Instrument::Type instrumentType, NoteRange *sourceRange, NoteRange *targetRange) {
   const std::string cacheKey =
-      std::to_string(static_cast<int>(instrumentType)) + "__" + sourceRange->toString(Accidental::Natural) +
-      "__" + targetRange->toString(Accidental::Natural);
+      std::to_string(instrumentType) + "__" + sourceRange->toString(Natural) +
+      "__" + targetRange->toString(Natural);
 
   if (rangeShiftOctave.find(cacheKey) == rangeShiftOctave.end()) {
     switch (instrumentType) {
@@ -641,9 +641,9 @@ std::optional<Note> Fabricator::getRootNoteMidRange(const std::string &voicingNo
       return std::nullopt;
     rootNotesByVoicingAndChord[key] = note;
     return note;
-  } else {
-    return it->second;
   }
+
+  return it->second;
 }
 
 
@@ -1029,9 +1029,9 @@ std::optional<const SegmentChoice *> Fabricator::getChoiceOfType(Program::Type p
 
   if (it != allChoices.end()) {
     return *it;
-  } else {
-    return std::nullopt;
   }
+
+  return std::nullopt;
 }
 
 
@@ -1201,7 +1201,7 @@ NoteRange Fabricator::computeProgramRange(const UUID &programId, const Instrumen
   for (const auto &event: events) {
     auto voiceOpt = sourceMaterial->getVoiceOfEvent(event);
     if (voiceOpt.has_value() && voiceOpt.value()->type == instrumentType &&
-        Note::of(event->tones).pitchClass != PitchClass::Atonal) {
+        Note::of(event->tones).pitchClass != Atonal) {
       auto tones = CsvUtils::split(event->tones);
       notes.insert(notes.end(), tones.begin(), tones.end());
     }

--- a/engine/src/fabricator/MarbleBag.cpp
+++ b/engine/src/fabricator/MarbleBag.cpp
@@ -108,14 +108,14 @@ std::string MarbleBag::toString() const {
 /**
  * @return true if the marble bag is completely empty
  */
-bool MarbleBag::empty() {
+bool MarbleBag::empty() const {
   return 0 == size();
 }
 
 /**
  * @return true if there are any marbles in the bag
  */
-bool MarbleBag::isPresent() {
+bool MarbleBag::isPresent() const {
   return 0 < size();
 }
 

--- a/engine/src/fabricator/MarbleBag.cpp
+++ b/engine/src/fabricator/MarbleBag.cpp
@@ -20,9 +20,8 @@ UUID MarbleBag::pick() {
   }
   std::sort(phases.begin(), phases.end());
 
-  std::optional<UUID> pick;
   for (const auto &phase: phases) {
-    pick = pickPhase(phase);
+    std::optional<UUID> pick = pickPhase(phase);
     if (pick.has_value())
       return pick.value();
   }

--- a/engine/src/fabricator/MarbleBag.cpp
+++ b/engine/src/fabricator/MarbleBag.cpp
@@ -142,7 +142,7 @@ std::optional<UUID> MarbleBag::pickPhase(const int phase) {
   if (total == 0)
     return blocks[0].id;
 
-  std::uniform_int_distribution<> distrib(0, total - 1);
+  std::uniform_int_distribution distrib(0, total - 1);
   const int pickIdx = distrib(gen);
 
   for (const Group &block: blocks) {
@@ -166,7 +166,7 @@ int MarbleBag::quickPick(const int total) {
     throw FabricationException("Cannot pick from empty set");
   std::random_device rd;
   std::mt19937 gen(rd());
-  std::uniform_int_distribution<> distrib(0, total - 1);
+  std::uniform_int_distribution distrib(0, total - 1);
   return distrib(gen);
 }
 

--- a/engine/src/fabricator/MarbleBag.cpp
+++ b/engine/src/fabricator/MarbleBag.cpp
@@ -15,8 +15,8 @@ using namespace XJ;
  */
 UUID MarbleBag::pick() {
   std::vector<int> phases;
-  for (const auto &entry: marbles) {
-    phases.push_back(entry.first);
+  for (const auto &[phase, marbles]: marbles) {
+    phases.push_back(phase);
   }
   std::sort(phases.begin(), phases.end());
 
@@ -36,8 +36,8 @@ UUID MarbleBag::pick() {
  * @param toAdd map of marble id to quantity
  */
 void MarbleBag::addAll(const int phase, const std::map<UUID, int> &toAdd) {
-  for (const auto &entry: toAdd)
-    add(phase, entry.first, entry.second);
+  for (const auto &[id, qty]: toAdd)
+    add(phase, id, qty);
 }
 
 /**
@@ -73,9 +73,9 @@ void MarbleBag::add(const int phase, const UUID &id, const int qty) {
  */
 int MarbleBag::size() const {
   int total = 0;
-  for (const auto &phase: marbles) {
-    for (const auto &marble: phase.second) {
-      total += marble.second;
+  for (const auto &[phase, marbles]: marbles) {
+    for (const auto &[id, qty]: marbles) {
+      total += qty;
     }
   }
   return total;
@@ -86,12 +86,12 @@ int MarbleBag::size() const {
  */
 std::string MarbleBag::toString() const {
   std::string result;
-  for (const auto &phase: marbles) {
-    std::string phaseStr = "Phase" + std::to_string(phase.first) + "[";
-    for (const auto &marble: phase.second) {
-      phaseStr += marble.first + ":" + std::to_string(marble.second) + ", ";
+  for (const auto &[phase, marbleMap]: marbles) {
+    std::string phaseStr = "Phase" + std::to_string(phase) + "[";
+    for (const auto &[id, qty]: marbleMap) {
+      phaseStr += id + ":" + std::to_string(qty) + ", ";
     }
-    if (!phase.second.empty()) {
+    if (!marbleMap.empty()) {
       phaseStr.pop_back(); // remove last comma
       phaseStr.pop_back(); // remove last space
     }
@@ -129,10 +129,10 @@ std::optional<UUID> MarbleBag::pickPhase(const int phase) {
   int total = 0;
   std::vector<Group> blocks;
 
-  for (const auto &entry: marbles[phase]) {
-    if (entry.second > 0) {
-      blocks.emplace_back(entry.first, total, total + entry.second);
-      total += entry.second;
+  for (const auto &[id, qty]: marbles[phase]) {
+    if (qty > 0) {
+      blocks.emplace_back(id, total, total + qty);
+      total += qty;
     }
   }
 

--- a/engine/src/fabricator/MarbleBag.cpp
+++ b/engine/src/fabricator/MarbleBag.cpp
@@ -85,7 +85,7 @@ int MarbleBag::size() const {
 /**
  * Display as string
  */
-std::string MarbleBag::toString() {
+std::string MarbleBag::toString() const {
   std::string result;
   for (const auto &phase: marbles) {
     std::string phaseStr = "Phase" + std::to_string(phase.first) + "[";

--- a/engine/src/fabricator/MarbleBag.cpp
+++ b/engine/src/fabricator/MarbleBag.cpp
@@ -72,7 +72,7 @@ void MarbleBag::add(const int phase, const UUID &id, const int qty) {
  *
  * @return {number}
  */
-int MarbleBag::size() {
+int MarbleBag::size() const {
   int total = 0;
   for (const auto &phase: marbles) {
     for (const auto &marble: phase.second) {

--- a/engine/src/fabricator/NotePicker.cpp
+++ b/engine/src/fabricator/NotePicker.cpp
@@ -25,7 +25,7 @@ Note NotePicker::pick(const Note eventNote) {
 
   std::optional<Note> picked = std::nullopt;
 
-  if (PitchClass::Atonal == noteInAvailableOctave.pitchClass) {
+  if (Atonal == noteInAvailableOctave.pitchClass) {
     picked = pickRandom(voicingNotes);
   } else {
     std::vector<RankedNote> rankedNotes;

--- a/engine/src/fabricator/NotePicker.cpp
+++ b/engine/src/fabricator/NotePicker.cpp
@@ -35,7 +35,7 @@ Note NotePicker::pick(const Note eventNote) {
     }
 
     // Find the minimum delta
-    const auto minElementIter = std::min_element(rankedNotes.begin(), rankedNotes.end(), [](RankedNote &a, RankedNote &b) {
+    const auto minElementIter = std::min_element(rankedNotes.begin(), rankedNotes.end(), [](const RankedNote &a, const RankedNote &b) {
       return abs(a.getDelta()) < abs(b.getDelta());
     });
 
@@ -72,7 +72,7 @@ Note NotePicker::removePicked(const Note picked)  {
 }
 
 
-Note NotePicker::seekInversion(const Note source, NoteRange range, std::set<Note> options) const {
+Note NotePicker::seekInversion(const Note source, const NoteRange &range, const std::set<Note> &options) const {
   if (!seekInversions) return source;
 
   if (range.high.has_value() && range.high.value() < source) {

--- a/engine/src/fabricator/NotePicker.cpp
+++ b/engine/src/fabricator/NotePicker.cpp
@@ -65,7 +65,6 @@ NoteRange NotePicker::getTargetRange()  {
 Note NotePicker::removePicked(const Note picked)  {
   const auto it = voicingNotes.find(picked);
   if (it != voicingNotes.end()) {
-    Note pickedNote = *it;
     voicingNotes.erase(it);
   }
   return picked;

--- a/engine/src/fabricator/NotePicker.cpp
+++ b/engine/src/fabricator/NotePicker.cpp
@@ -7,14 +7,14 @@ using namespace XJ;
 
 NotePicker::NotePicker(const NoteRange& targetRange, const std::set<Note>& voicingNotes, const bool seekInversions)  {
   this->targetRange = NoteRange::copyOf(targetRange);
-  this->voicingNotes = std::set<Note>(voicingNotes);
+  this->voicingNotes = std::set(voicingNotes);
   this->voicingRange = NoteRange::ofNotes(voicingNotes);
   this->seekInversions = seekInversions;
 }
 
 NotePicker::NotePicker(const NoteRange& targetRange, const std::vector<Note>& voicingNotes, const bool seekInversions)  {
   this->targetRange = NoteRange::copyOf(targetRange);
-  this->voicingNotes = std::set<Note>(voicingNotes.begin(), voicingNotes.end());
+  this->voicingNotes = std::set(voicingNotes.begin(), voicingNotes.end());
   this->voicingRange = NoteRange::ofNotes(voicingNotes);
   this->seekInversions = seekInversions;
 }
@@ -106,7 +106,7 @@ Note NotePicker::seekInversion(const Note source, const NoteRange &range, const 
 
 std::optional<Note> NotePicker::pickRandom(std::set<Note> fromNotes) {
   if (fromNotes.empty()) return std::nullopt;
-  std::vector<Note> fromNotesVec(fromNotes.begin(), fromNotes.end());
+  std::vector fromNotesVec(fromNotes.begin(), fromNotes.end());
   return {fromNotesVec[MarbleBag::quickPick(fromNotes.size())]};
 }
 

--- a/engine/src/fabricator/NotePicker.cpp
+++ b/engine/src/fabricator/NotePicker.cpp
@@ -72,7 +72,7 @@ Note NotePicker::removePicked(const Note picked)  {
 }
 
 
-Note NotePicker::seekInversion(const Note source, NoteRange range, std::set<Note> options) {
+Note NotePicker::seekInversion(const Note source, NoteRange range, std::set<Note> options) const {
   if (!seekInversions) return source;
 
   if (range.high.has_value() && range.high.value() < source) {

--- a/engine/src/fabricator/RankedNote.cpp
+++ b/engine/src/fabricator/RankedNote.cpp
@@ -19,6 +19,6 @@ Note RankedNote::getTones() const {
 }
 
 
-int RankedNote::getDelta() {
+int RankedNote::getDelta() const {
   return delta;
 }

--- a/engine/src/fabricator/RankedNote.cpp
+++ b/engine/src/fabricator/RankedNote.cpp
@@ -14,7 +14,7 @@ RankedNote::RankedNote(
 }
 
 
-Note RankedNote::getTones() {
+Note RankedNote::getTones() const {
   return note;
 }
 

--- a/engine/src/fabricator/SegmentRetrospective.cpp
+++ b/engine/src/fabricator/SegmentRetrospective.cpp
@@ -56,7 +56,7 @@ void SegmentRetrospective::load() {
 std::optional<SegmentChoice *>
 SegmentRetrospective::getPreviousChoiceOfType(const Segment *segment, const Program::Type programType) {
   const auto c = entityStore->readChoice(segment->id, programType);
-  return (c.has_value() && programType == c.value()->programType) ? c : std::nullopt;
+  return c.has_value() && programType == c.value()->programType ? c : std::nullopt;
 }
 
 std::set<SegmentChoiceArrangementPick *> SegmentRetrospective::getPicks() {

--- a/engine/src/meme/MemeConstellation.cpp
+++ b/engine/src/meme/MemeConstellation.cpp
@@ -5,15 +5,11 @@
 using namespace XJ;
 
 std::string MemeConstellation::fromNames(const std::set<std::string> &names) {
-  std::unordered_map<std::string, bool> uniqueNames;
+  std::set<std::string> uniqueNames;
   for (const auto &meme: names) {
-    uniqueNames[meme] = true;
+    uniqueNames.emplace(meme);
   }
-  std::set<std::string> pieces;
-  for (const auto &pair: uniqueNames) {
-    pieces.insert(pair.first);
-  }
-  return join(CONSTELLATION_DELIMITER, pieces);
+  return join(CONSTELLATION_DELIMITER, uniqueNames);
 }
 
 std::set<std::string> MemeConstellation::toNames(const std::string &constellation)  {

--- a/engine/src/meme/MemeIsometry.cpp
+++ b/engine/src/meme/MemeIsometry.cpp
@@ -24,7 +24,7 @@ MemeIsometry MemeIsometry::none() {
   return MemeIsometry(MemeTaxonomy(), std::set<std::string>());
 }
 
-int MemeIsometry::score(const std::set<std::string> &targets) {
+int MemeIsometry::score(const std::set<std::string> &targets) const {
   if (!isAllowed(targets)) return 0;
 
   int sum = 0;

--- a/engine/src/meme/MemeIsometry.cpp
+++ b/engine/src/meme/MemeIsometry.cpp
@@ -60,7 +60,7 @@ void MemeIsometry::add(const SegmentMeme &meme) {
   add(meme.name);
 }
 
-bool MemeIsometry::isAllowed(const std::set<std::string> &memes) {
+bool MemeIsometry::isAllowed(const std::set<std::string> &memes) const {
   return stack.isAllowed(memes);
 }
 

--- a/engine/src/meme/MemeIsometry.cpp
+++ b/engine/src/meme/MemeIsometry.cpp
@@ -1,7 +1,6 @@
 // Copyright (c) XJ Music Inc. (https://xjmusic.com) All Rights Reserved.
 
 #include <sstream>
-#include <unordered_set>
 
 #include "xjmusic/meme/MemeIsometry.h"
 

--- a/engine/src/meme/MemeIsometry.cpp
+++ b/engine/src/meme/MemeIsometry.cpp
@@ -68,7 +68,7 @@ std::set<std::string> MemeIsometry::getSources() {
   return sources;
 }
 
-std::string MemeIsometry::getConstellation() {
+std::string MemeIsometry::getConstellation() const {
   return MemeConstellation::fromNames(sources);
 }
 

--- a/engine/src/meme/MemeStack.cpp
+++ b/engine/src/meme/MemeStack.cpp
@@ -62,10 +62,9 @@ bool MemeStack::isAllowed(const std::set<std::string> &sources, const std::set<s
 
 bool MemeStack::isValid() {
   const std::vector<std::string> targets(memes.begin(), memes.end());
-  std::vector<std::string> subTargets;
 
   for (int a = 0; a < targets.size(); a++) {
-    subTargets = targets;
+    std::vector<std::string> subTargets = targets;
     subTargets.erase(subTargets.begin() + a);
     for (int b = 0; b < memes.size(); b++) {
       std::set<std::string> m1(subTargets.begin(), subTargets.end());

--- a/engine/src/meme/MemeStack.cpp
+++ b/engine/src/meme/MemeStack.cpp
@@ -62,21 +62,21 @@ bool MemeStack::isAllowed(const std::set<std::string> &sources, const std::set<s
 }
 
 bool MemeStack::isValid() {
-  const std::vector<std::string> targets(memes.begin(), memes.end());
+  const std::vector targets(memes.begin(), memes.end());
 
   for (int a = 0; a < targets.size(); a++) {
     std::vector<std::string> subTargets = targets;
     subTargets.erase(subTargets.begin() + a);
     for (int b = 0; b < memes.size(); b++) {
-      std::set<std::string> m1(subTargets.begin(), subTargets.end());
-      std::set<std::string> m2 = {targets[a]};
+      std::set m1(subTargets.begin(), subTargets.end());
+      std::set m2 = {targets[a]};
       if (!isAllowed(m1, m2))
         return false;
     }
   }
 
   // meme categories https://github.com/xjmusic/xjmusic/issues/209
-  const std::set<std::string> targetSet(memes.begin(), memes.end());
+  const std::set targetSet(memes.begin(), memes.end());
   return taxonomy.isAllowed(targetSet);
 }
 

--- a/engine/src/meme/MemeStack.cpp
+++ b/engine/src/meme/MemeStack.cpp
@@ -13,6 +13,7 @@ using namespace XJ;
 /**
  Constructor from taxonomy and memes
 
+ @param taxonomy taxonomy
  @param from from which to create stack
  */
 MemeStack::MemeStack(MemeTaxonomy taxonomy, const std::set<std::string> &from) {

--- a/engine/src/meme/MemeTaxonomy.cpp
+++ b/engine/src/meme/MemeTaxonomy.cpp
@@ -2,7 +2,6 @@
 
 #include <sstream>
 #include <regex>
-#include <unordered_set>
 #include <set>
 
 #include <spdlog/spdlog.h>

--- a/engine/src/meme/MemeTaxonomy.cpp
+++ b/engine/src/meme/MemeTaxonomy.cpp
@@ -140,7 +140,7 @@ MemeTaxonomy::MemeTaxonomy(const std::string &raw) : MemeTaxonomy() {
 }
 
 
-MemeTaxonomy::MemeTaxonomy(std::set<MapStringToOneOrManyString> &data) {
+MemeTaxonomy::MemeTaxonomy(const std::set<MapStringToOneOrManyString> &data) {
   categories.clear();
   for (auto &d: data) {
     try {

--- a/engine/src/meme/MemeTaxonomy.cpp
+++ b/engine/src/meme/MemeTaxonomy.cpp
@@ -163,7 +163,7 @@ std::string MemeTaxonomy::toString() const {
 }
 
 
-std::set<MapStringToOneOrManyString> MemeTaxonomy::toList() {
+std::set<MapStringToOneOrManyString> MemeTaxonomy::toList() const {
   std::set<MapStringToOneOrManyString> data;
   for (const auto &category: categories) {
     auto map = category.toMap();

--- a/engine/src/meme/MemeTaxonomy.cpp
+++ b/engine/src/meme/MemeTaxonomy.cpp
@@ -77,7 +77,7 @@ MemeCategory::MemeCategory(const std::string *raw) {
 
 MemeCategory::MemeCategory(const MapStringToOneOrManyString &data) {
   const auto it = data.find(KEY_NAME);
-  name = (it != data.end() && std::holds_alternative<std::string>(it->second))
+  name = it != data.end() && std::holds_alternative<std::string>(it->second)
          ? sanitize(std::get<std::string>(it->second))
          : DEFAULT_CATEGORY_NAME;
 
@@ -112,7 +112,7 @@ bool MemeCategory::hasMemes() const {
 
 
 std::string MemeCategory::toString() const {
-  std::vector<std::string> sortedMemes(memes.begin(), memes.end());
+  std::vector sortedMemes(memes.begin(), memes.end());
   std::sort(sortedMemes.begin(), sortedMemes.end());
   return name + "[" + StringUtils::join(sortedMemes, MEME_SEPARATOR) + "]";
 }
@@ -210,7 +210,7 @@ MemeTaxonomy MemeTaxonomy::fromList(
     for (const auto &[key, value]: map) {
       if (std::holds_alternative<std::vector<std::string>>(value)) {
         auto v = std::get<std::vector<std::string>>(value);
-        m[key] = std::set<std::string>(v.begin(), v.end());
+        m[key] = std::set(v.begin(), v.end());
       } else {
         m[key] = std::get<std::string>(value);
       }

--- a/engine/src/meme/ParseAnti.cpp
+++ b/engine/src/meme/ParseAnti.cpp
@@ -30,7 +30,7 @@ bool ParseAnti::isViolatedBy(const ParseAnti &target) const {
          (!valid && target.valid && body == target.body);
 }
 
-bool ParseAnti::isAllowed(const std::vector<ParseAnti> &memes) {
+bool ParseAnti::isAllowed(const std::vector<ParseAnti> &memes) const {
   return std::all_of(memes.begin(), memes.end(), [this](const ParseAnti &meme) {
     return !isViolatedBy(meme);
   });

--- a/engine/src/meme/ParseAnti.cpp
+++ b/engine/src/meme/ParseAnti.cpp
@@ -1,6 +1,5 @@
 // Copyright (c) XJ Music Inc. (https://xj.io) All Rights Reserved.
 
-#include <set>
 #include "xjmusic/meme/ParseAnti.h"
 
 using namespace XJ;

--- a/engine/src/meme/ParseNumeric.cpp
+++ b/engine/src/meme/ParseNumeric.cpp
@@ -1,6 +1,5 @@
 // Copyright (c) XJ Music Inc. (https://xj.io) All Rights Reserved.
 
-#include <set>
 #include "xjmusic/meme/ParseNumeric.h"
 
 using namespace XJ;

--- a/engine/src/meme/ParseNumeric.cpp
+++ b/engine/src/meme/ParseNumeric.cpp
@@ -42,7 +42,7 @@ bool ParseNumeric::isViolatedBy(const ParseNumeric &target) const {
   return valid && target.valid && body == target.body && prefix != target.prefix;
 }
 
-bool ParseNumeric::isAllowed(const std::vector<ParseNumeric> &memes) {
+bool ParseNumeric::isAllowed(const std::vector<ParseNumeric> &memes) const {
   return std::all_of(memes.begin(), memes.end(), [this](const ParseNumeric &meme) {
     return !isViolatedBy(meme);
   });

--- a/engine/src/meme/ParseStrong.cpp
+++ b/engine/src/meme/ParseStrong.cpp
@@ -27,7 +27,7 @@ ParseStrong ParseStrong::fromString(const std::string &raw) {
   return ParseStrong(raw);
 }
 
-bool ParseStrong::isAllowed(const std::vector<ParseStrong> &memes) {
+bool ParseStrong::isAllowed(const std::vector<ParseStrong> &memes) const {
   if (!valid) return true;
   return !std::all_of(memes.begin(), memes.end(), [this](const ParseStrong &meme) {
     return body != meme.body;

--- a/engine/src/meme/ParseUnique.cpp
+++ b/engine/src/meme/ParseUnique.cpp
@@ -31,7 +31,7 @@ bool ParseUnique::isViolatedBy(const ParseUnique &target) const {
   return valid && target.valid && body == target.body;
 }
 
-bool ParseUnique::isAllowed(const std::vector<ParseUnique> &memes) {
+bool ParseUnique::isAllowed(const std::vector<ParseUnique> &memes) const {
   return std::all_of(memes.begin(), memes.end(), [this](const ParseUnique &meme) {
     return !isViolatedBy(meme);
   });

--- a/engine/src/music/Accidental.cpp
+++ b/engine/src/music/Accidental.cpp
@@ -28,12 +28,14 @@ Accidental XJ::accidentalOf(const std::string &name) {
 
 Accidental XJ::accidentalOfBeginning(const std::string &name) {
   const std::string normalized = accidentalNormalized(name);
+
   if (normalized[0] == '#')
-    return Accidental::Sharp;
-  else if (normalized[0] == 'b')
-    return Accidental::Flat;
-  else
-    return Accidental::Natural;
+    return Sharp;
+
+  if (normalized[0] == 'b')
+    return Flat;
+
+  return Natural;
 }
 
 

--- a/engine/src/music/Accidental.cpp
+++ b/engine/src/music/Accidental.cpp
@@ -22,7 +22,7 @@ Accidental XJ::accidentalOf(const std::string &name) {
   const int numFlattish = StringUtils::countMatches(accidentalFlattishIn, normalized);
 
   // sharp/flat has precedent over sharpish/flattish; overall default is sharp
-  return (numFlats > numSharps || numFlats == numSharps && numFlattish > numSharpish) ? Flat : Sharp;
+  return numFlats > numSharps || numFlats == numSharps && numFlattish > numSharpish ? Flat : Sharp;
 }
 
 

--- a/engine/src/music/Chord.cpp
+++ b/engine/src/music/Chord.cpp
@@ -176,9 +176,9 @@ Chord::Chord(const std::string &input) : slashRoot(SlashRoot::none()) {
   // Don't set values if there's nothing to set
   if (input.empty()) {
     description = "";
-    root = PitchClass::Atonal;
+    root = Atonal;
     slashRoot = SlashRoot::none();
-    accidental = Accidental::Natural;
+    accidental = Natural;
     return;
   }
 
@@ -240,9 +240,9 @@ std::string Chord::normalize(const std::string &input) {
 
   if (it != forms.end()) {
     return it->description;
-  } else {
-    return input;
   }
+
+  return input;
 }
 
 
@@ -252,7 +252,7 @@ Chord Chord::of(const std::string &name) {
 
 
 bool Chord::isNoChord() const {
-  return root == PitchClass::Atonal;
+  return root == Atonal;
 }
 
 
@@ -262,5 +262,5 @@ bool Chord::isAcceptable(const Chord &other) const {
 
 
 bool Chord::has_value() const {
-  return root != PitchClass::Atonal;
+  return root != Atonal;
 }

--- a/engine/src/music/Chord.cpp
+++ b/engine/src/music/Chord.cpp
@@ -55,7 +55,7 @@ std::size_t ChordForm::hashCode() {
   for (const auto &synonym: synonyms) {
     h2 ^= std::hash<std::string>{}(synonym.match) + 0x9e3779b9 + (h2 << 6) + (h2 >> 2);
   }
-  return h1 ^ (h2 << 1);
+  return h1 ^ h2 << 1;
 }
 
 

--- a/engine/src/music/Note.cpp
+++ b/engine/src/music/Note.cpp
@@ -44,7 +44,7 @@ bool Note::operator>=(const Note &other) const {
 std::string Note::ATONAL = "X";
 
 
-Note::Note() : pitchClass(PitchClass::Atonal), octave(0) {}// Default constructor
+Note::Note() : pitchClass(Atonal), octave(0) {}// Default constructor
 
 
 Note::Note(const std::string &name) : pitchClass(pitchClassOf(name)), octave(octaveOf(name)) {}
@@ -55,7 +55,7 @@ Note::Note(const PitchClass pitchClass, const int octave) : pitchClass(pitchClas
 
 Note Note::of(const std::string &name) {
   return name.empty()
-             ? Note::atonal()
+             ? atonal()
              : Note(name);
 }
 
@@ -66,7 +66,7 @@ Note Note::of(PitchClass pitchClass, int octave) {
 
 
 Note Note::atonal() {
-  return {PitchClass::Atonal, 0};
+  return {Atonal, 0};
 }
 
 
@@ -79,7 +79,7 @@ std::optional<Note> Note::ifValid(const std::string &name) {
 
 std::optional<Note> Note::ifTonal(const std::string &name) {
   if (!isValid(name)) return std::nullopt;
-  auto note = Note::of(name);
+  auto note = of(name);
   if (note.isAtonal()) return std::nullopt;
   return note;
 }
@@ -183,5 +183,5 @@ Note Note::next(const PitchClass target, const int delta) const {
       return n;
   }
   throw std::runtime_error(
-      "Unable to determine first occurrence of " + stringOf(target, Accidental::Natural) + "from here!");
+      "Unable to determine first occurrence of " + stringOf(target, Natural) + "from here!");
 }

--- a/engine/src/music/Note.cpp
+++ b/engine/src/music/Note.cpp
@@ -4,6 +4,7 @@
 
 #include "xjmusic/music/Note.h"
 #include "xjmusic/music/Octave.h"
+#include "xjmusic/music/Step.h"
 
 using namespace XJ;
 
@@ -54,8 +55,8 @@ Note::Note(const PitchClass pitchClass, const int octave) : pitchClass(pitchClas
 
 Note Note::of(const std::string &name) {
   return name.empty()
-         ? Note::atonal()
-         : Note(name);
+             ? Note::atonal()
+             : Note(name);
 }
 
 
@@ -71,8 +72,8 @@ Note Note::atonal() {
 
 std::optional<Note> Note::ifValid(const std::string &name) {
   return isValid(name)
-         ? std::optional<Note>(Note(name))
-         : std::nullopt;
+             ? std::optional<Note>(Note(name))
+             : std::nullopt;
 }
 
 
@@ -172,7 +173,7 @@ Note Note::nextDown(const PitchClass target) {
 }
 
 
-Note Note::next(const PitchClass target, const int delta) {
+Note Note::next(const PitchClass target, const int delta) const {
   if (isAtonal() || pitchClass == target)
     return *this;
   Note n = *this;

--- a/engine/src/music/Note.cpp
+++ b/engine/src/music/Note.cpp
@@ -168,7 +168,7 @@ Note Note::nextUp(const PitchClass target) const {
 }
 
 
-Note Note::nextDown(const PitchClass target) {
+Note Note::nextDown(const PitchClass target) const {
   return next(target, -1);
 }
 

--- a/engine/src/music/Note.cpp
+++ b/engine/src/music/Note.cpp
@@ -163,7 +163,7 @@ bool Note::isAtonal() const {
 }
 
 
-Note Note::nextUp(const PitchClass target) {
+Note Note::nextUp(const PitchClass target) const {
   return next(target, 1);
 }
 

--- a/engine/src/music/Note.cpp
+++ b/engine/src/music/Note.cpp
@@ -44,13 +44,13 @@ bool Note::operator>=(const Note &other) const {
 std::string Note::ATONAL = "X";
 
 
-Note::Note() : pitchClass(Atonal), octave(0) {}// Default constructor
+Note::Note() : octave(0), pitchClass(Atonal) {}// Default constructor
 
 
-Note::Note(const std::string &name) : pitchClass(pitchClassOf(name)), octave(octaveOf(name)) {}
+Note::Note(const std::string &name) : octave(octaveOf(name)), pitchClass(pitchClassOf(name)) {}
 
 
-Note::Note(const PitchClass pitchClass, const int octave) : pitchClass(pitchClass), octave(octave) {}
+Note::Note(const PitchClass pitchClass, const int octave) : octave(octave), pitchClass(pitchClass) {}
 
 
 Note Note::of(const std::string &name) {
@@ -72,7 +72,7 @@ Note Note::atonal() {
 
 std::optional<Note> Note::ifValid(const std::string &name) {
   return isValid(name)
-             ? std::optional<Note>(Note(name))
+             ? std::optional(Note(name))
              : std::nullopt;
 }
 

--- a/engine/src/music/NoteRange.cpp
+++ b/engine/src/music/NoteRange.cpp
@@ -38,7 +38,7 @@ NoteRange NoteRange::copyOf(const NoteRange &range) {
 
 
 NoteRange NoteRange::ofNotes(std::vector<Note> notes) {
-  const std::set<Note> properNotes(notes.begin(), notes.end());
+  const std::set properNotes(notes.begin(), notes.end());
   return ofNotes(properNotes);
 }
 

--- a/engine/src/music/NoteRange.cpp
+++ b/engine/src/music/NoteRange.cpp
@@ -157,13 +157,13 @@ NoteRange NoteRange::shifted(const int inc) const {
 
 
 bool NoteRange::empty() const {
-  return !low.has_value() || !high.has_value() || PitchClass::Atonal == low->pitchClass ||
-         PitchClass::Atonal == high->pitchClass;
+  return !low.has_value() || !high.has_value() || Atonal == low->pitchClass ||
+         Atonal == high->pitchClass;
 }
 
 
 std::optional<Note> NoteRange::getNoteNearestMedian(const PitchClass root) {
-  if (PitchClass::Atonal == root) return std::nullopt;
+  if (Atonal == root) return std::nullopt;
   auto median = getMedianNote();
   if (!median.has_value()) return std::nullopt;
   if (root == median->pitchClass) return median;

--- a/engine/src/music/Octave.cpp
+++ b/engine/src/music/Octave.cpp
@@ -17,7 +17,7 @@ int XJ::octaveOf(const std::string &text) {
   const std::string prepared = std::regex_replace(StringUtils::stripExtraSpaces(text), std::regex("--"), "-");
   if (std::regex_search(prepared, matcher, octaveRgx)) {
     return std::stoi(matcher[1].str());
-  } else {
-    return 0;
   }
+
+  return 0;
 }

--- a/engine/src/music/Root.cpp
+++ b/engine/src/music/Root.cpp
@@ -14,7 +14,7 @@ Root::Root(const std::string &name) {
     const std::string normalized = accidentalNormalized(name);
 
     // as a default, the whole thing is remaining text, and pitch class is None
-    pitchClass = PitchClass::Atonal;
+    pitchClass = Atonal;
     remainingText = normalized;
 
     evaluate(rgxNote, normalized);

--- a/engine/src/music/SlashRoot.cpp
+++ b/engine/src/music/SlashRoot.cpp
@@ -81,5 +81,5 @@ std::string SlashRoot::display(const Accidental withOptional) const {
 
 
 bool SlashRoot::operator==(const SlashRoot &other) const {
-  return ((!post.empty() && !other.post.empty() && post == other.post) || pitchClass == other.pitchClass);
+  return (!post.empty() && !other.post.empty() && post == other.post) || pitchClass == other.pitchClass;
 }

--- a/engine/src/music/SlashRoot.cpp
+++ b/engine/src/music/SlashRoot.cpp
@@ -41,7 +41,7 @@ SlashRoot SlashRoot::none() {
 
 
 PitchClass SlashRoot::orDefault(PitchClass dpc) const {
-  if (pitchClass == PitchClass::Atonal) return dpc;
+  if (pitchClass == Atonal) return dpc;
   return pitchClass.value_or(dpc);
 }
 
@@ -64,17 +64,19 @@ bool SlashRoot::has_value() const {
 
 
 std::string SlashRoot::display(const Accidental withOptional) const {
-  if (pitchClass.has_value() && PitchClass::Atonal != pitchClass) {
+  if (pitchClass.has_value() && Atonal != pitchClass) {
     std::ostringstream oss;
     oss << "/" << stringOf(pitchClass.value(), withOptional);
     return oss.str();
-  } else if (!post.empty()) {
+  }
+
+  if (!post.empty()) {
     std::ostringstream oss;
     oss << "/" << post;
     return oss.str();
-  } else {
-    return "";
   }
+
+  return "";
 }
 
 

--- a/engine/src/music/Step.cpp
+++ b/engine/src/music/Step.cpp
@@ -231,10 +231,11 @@ int Step::delta(const PitchClass from, const PitchClass to) {
 Step Step::step(PitchClass from, const int inc) {
   if (0 < inc)
     return stepUp(from, inc);
-  else if (0 > inc)
+
+  if (0 > inc)
     return stepDown(from, -inc);
-  else
-    return {from, 0};
+
+  return {from, 0};
 }
 
 

--- a/engine/src/music/StickyBun.cpp
+++ b/engine/src/music/StickyBun.cpp
@@ -51,7 +51,7 @@ std::vector<Note> StickyBun::replaceAtonal(std::vector<Note> source, const std::
 }
 
 
-Note StickyBun::compute(std::vector<Note> voicingNotes, const int index) const {
+Note StickyBun::compute(const std::vector<Note> &voicingNotes, const int index) const {
   const float valueRatio =
       static_cast<float>(values[std::min(index, static_cast<int>(values.size()) - 1)]) /
       static_cast<float>(MAX_VALUE);

--- a/engine/src/music/StickyBun.cpp
+++ b/engine/src/music/StickyBun.cpp
@@ -26,8 +26,8 @@ StickyBun::StickyBun(UUID eventId, const int size) : eventId(std::move(eventId))
 }
 
 
-StickyBun::StickyBun(UUID eventId, std::vector<int> values) : eventId(std::move(eventId)),
-                                                              values(std::move(values)) {}
+StickyBun::StickyBun(UUID eventId, std::vector<int> values) : values(std::move(values)),
+                                                              eventId(std::move(eventId)) {}
 
 
 std::string StickyBun::computeMetaKey(const UUID &id) {

--- a/engine/src/music/StickyBun.cpp
+++ b/engine/src/music/StickyBun.cpp
@@ -14,7 +14,7 @@ using json = nlohmann::json;
 std::random_device StickyBun::rd;
 std::mt19937 StickyBun::gen(rd());
 int StickyBun::MAX_VALUE = 100;
-std::uniform_int_distribution<> StickyBun::distrib(0, static_cast<int>(MAX_VALUE) - 1);
+std::uniform_int_distribution<> StickyBun::distrib(0, MAX_VALUE - 1);
 std::string StickyBun::META_KEY_TEMPLATE = "StickyBun_";
 
 
@@ -32,7 +32,7 @@ StickyBun::StickyBun(UUID eventId, std::vector<int> values) : eventId(std::move(
 
 std::string StickyBun::computeMetaKey(const UUID &id) {
   std::ostringstream oss; 
-  oss << StickyBun::META_KEY_TEMPLATE << id;
+  oss << META_KEY_TEMPLATE << id;
   return oss.str();
 }
 

--- a/engine/src/music/Tuning.cpp
+++ b/engine/src/music/Tuning.cpp
@@ -70,7 +70,7 @@ void Tuning::validate() const {
     throw std::runtime_error(ss.str());
   }
 
-  if (rootNote.pitchClass == PitchClass::Atonal)
+  if (rootNote.pitchClass == Atonal)
     throw std::runtime_error("Root note must have a pitch class (e.g. 'C')");
 
   if (!(ROOT_OCTAVE_MINIMUM <= rootNote.octave && ROOT_OCTAVE_MAXIMUM >= rootNote.octave)) {

--- a/engine/src/segment/Chain.cpp
+++ b/engine/src/segment/Chain.cpp
@@ -25,7 +25,7 @@ static const std::map<std::string, Chain::State> stateNameValues = EntityUtils::
 
 Chain::Type Chain::parseType(const std::string &value) {
   if (typeNameValues.count(value) == 0) {
-    return Chain::Type::Preview;
+    return Preview;
   }
   return typeNameValues.at(value);
 }
@@ -33,18 +33,18 @@ Chain::Type Chain::parseType(const std::string &value) {
 
 Chain::State Chain::parseState(const std::string &value) {
   if (stateNameValues.count(value) == 0) {
-    return Chain::State::Draft;
+    return Draft;
   }
   return stateNameValues.at(value);
 }
 
 
-std::string Chain::toString(const Chain::Type &type) {
+std::string Chain::toString(const Type &type) {
   return typeValueNames.at(type);
 }
 
 
-std::string Chain::toString(const Chain::State &state) {
+std::string Chain::toString(const State &state) {
   return stateValueNames.at(state);
 }
 

--- a/engine/src/segment/Segment.cpp
+++ b/engine/src/segment/Segment.cpp
@@ -28,7 +28,7 @@ static const std::map<std::string, Segment::State> stateNameValues = EntityUtils
 
 Segment::Type Segment::parseType(const std::string &value) {
   if (typeNameValues.count(value) == 0) {
-    return Segment::Type::Pending;
+    return Pending;
   }
   return typeNameValues.at(value);
 }
@@ -36,18 +36,18 @@ Segment::Type Segment::parseType(const std::string &value) {
 
 Segment::State Segment::parseState(const std::string &value) {
   if (stateNameValues.count(value) == 0) {
-    return Segment::State::Planned;
+    return Planned;
   }
   return stateNameValues.at(value);
 }
 
 
-std::string Segment::toString(const Segment::Type &type) {
+std::string Segment::toString(const Type &type) {
   return typeValueNames.at(type);
 }
 
 
-std::string Segment::toString(const Segment::State &state) {
+std::string Segment::toString(const State &state) {
   return stateValueNames.at(state);
 }
 

--- a/engine/src/segment/SegmentEntityStore.cpp
+++ b/engine/src/segment/SegmentEntityStore.cpp
@@ -156,9 +156,9 @@ std::set<SegmentEntity *> SegmentEntityStore::readAllSegmentEntities(const std::
 
 std::vector<Segment> SegmentEntityStore::readAllSegmentsSpanning(const long fromChainMicros, const long toChainMicros) {
   std::vector<Segment> result;
-  for (auto &segment: segments) {
-    if (SegmentUtils::isSpanning(&segment.second, fromChainMicros, toChainMicros)) {
-      result.emplace_back(segment.second);
+  for (auto &[id, segment]: segments) {
+    if (SegmentUtils::isSpanning(&segment, fromChainMicros, toChainMicros)) {
+      result.emplace_back(segment);
     }
   }
   return result;

--- a/engine/src/segment/SegmentEntityStore.cpp
+++ b/engine/src/segment/SegmentEntityStore.cpp
@@ -72,15 +72,15 @@ SEGMENT_STORE_CORE_METHODS(SegmentMessage, SegmentMessages, segmentMessages)
 SEGMENT_STORE_CORE_METHODS(SegmentMeta, SegmentMetas, segmentMetas)
 
 
-Chain *SegmentEntityStore::put(const Chain &c) {
-  const auto cc = new Chain(c);
+Chain *SegmentEntityStore::put(const Chain &chain) {
+  const auto cc = new Chain(chain);
   this->chain = *cc;
   return cc;
 }
 
-Segment *SegmentEntityStore::put(const Segment &s) {
-  const auto sc = new Segment(s);
-  this->segments[s.id] = *sc;
+Segment *SegmentEntityStore::put(const Segment &segment) {
+  const auto sc = new Segment(segment);
+  this->segments[segment.id] = *sc;
   return sc;
 }
 

--- a/engine/src/segment/SegmentMessage.cpp
+++ b/engine/src/segment/SegmentMessage.cpp
@@ -17,13 +17,13 @@ static const std::map<std::string, SegmentMessage::Type> typeNameValues = Entity
 
 SegmentMessage::Type SegmentMessage::parseType(const std::string &value) {
   if (typeNameValues.count(value) == 0) {
-    return SegmentMessage::Type::Debug;
+    return Debug;
   }
   return typeNameValues.at(value);
 }
 
 
-std::string SegmentMessage::toString(const SegmentMessage::Type &type) {
+std::string SegmentMessage::toString(const Type &type) {
   return typeValueNames.at(type);
 }
 

--- a/engine/src/util/ConfigParser.cpp
+++ b/engine/src/util/ConfigParser.cpp
@@ -223,9 +223,9 @@ ConfigParser::ConfigParser(const std::string &input) {
 
 
 ConfigParser::ConfigParser(const std::string &input, const ConfigParser &defaults) : ConfigParser(input) {
-  for (const auto &pair: defaults.config) {
-    if (config.find(pair.first) == config.end()) {
-      config[pair.first] = pair.second;
+  for (const auto &[key, val]: defaults.config) {
+    if (config.find(key) == config.end()) {
+      config[key] = val;
     }
   }
 }
@@ -371,15 +371,15 @@ ConfigObjectValue::asMapOfSingleOrList() {
 std::map<std::string, std::variant<std::string, std::vector<std::string>>>
 ConfigObjectValue::asMapOfStringsOrListsOfStrings() const {
   std::map<std::string, std::variant<std::string, std::vector<std::string>>> map;
-  for (const auto &pair: data) {
-    if (std::holds_alternative<ConfigSingleValue>(pair.second)) {
-      map[pair.first] = std::get<ConfigSingleValue>(pair.second).getString();
-    } else if (std::holds_alternative<std::vector<ConfigSingleValue>>(pair.second)) {
+  for (const auto &[key, val]: data) {
+    if (std::holds_alternative<ConfigSingleValue>(val)) {
+      map[key] = std::get<ConfigSingleValue>(val).getString();
+    } else if (std::holds_alternative<std::vector<ConfigSingleValue>>(val)) {
       std::vector<std::string> values;
-      for (const auto &value: std::get<std::vector<ConfigSingleValue>>(pair.second)) {
+      for (const auto &value: std::get<std::vector<ConfigSingleValue>>(val)) {
         values.push_back(value.getString());
       }
-      map[pair.first] = values;
+      map[key] = values;
     }
   }
   return map;

--- a/engine/src/util/ConfigParser.cpp
+++ b/engine/src/util/ConfigParser.cpp
@@ -99,7 +99,6 @@ ConfigObjectValue parseObjectValue(const std::string &input) {
   std::istringstream iss(StringUtils::trim(input));
   std::vector<std::string> members;
   std::string piece;
-  std::string key;
   int inObject = 0;// depth inside an object
   int inList = 0;  // depth inside a list
   while (std::getline(iss, piece)) {
@@ -117,12 +116,11 @@ ConfigObjectValue parseObjectValue(const std::string &input) {
   }
 
   // Parse each piece of the members vector
-  std::string value;
   for (const auto &member: members) {
     const auto pos = member.find('=');
     if (pos != std::string::npos) {
-      key = StringUtils::trim(member.substr(0, pos));
-      value = StringUtils::trim(member.substr(pos + 1));
+      std::string key = StringUtils::trim(member.substr(0, pos));
+      std::string value = StringUtils::trim(member.substr(pos + 1));
       if (value.front() == '[' && value.back() == ']') {// Array
         obj.set(key, parseSimpleListValue(value.substr(1, value.size() - 2)));
       } else {

--- a/engine/src/util/ConfigParser.cpp
+++ b/engine/src/util/ConfigParser.cpp
@@ -369,7 +369,7 @@ ConfigObjectValue::asMapOfSingleOrList() {
 
 
 std::map<std::string, std::variant<std::string, std::vector<std::string>>>
-ConfigObjectValue::asMapOfStringsOrListsOfStrings() {
+ConfigObjectValue::asMapOfStringsOrListsOfStrings() const {
   std::map<std::string, std::variant<std::string, std::vector<std::string>>> map;
   for (const auto &pair: data) {
     if (std::holds_alternative<ConfigSingleValue>(pair.second)) {
@@ -386,7 +386,7 @@ ConfigObjectValue::asMapOfStringsOrListsOfStrings() {
 }
 
 
-unsigned long ConfigListValue::size() {
+unsigned long ConfigListValue::size() const {
   return data.size();
 }
 

--- a/engine/src/util/ConfigParser.cpp
+++ b/engine/src/util/ConfigParser.cpp
@@ -257,7 +257,7 @@ int ConfigSingleValue::getInt() const {
 }
 
 
-bool ConfigSingleValue::getBool() {
+bool ConfigSingleValue::getBool() const {
   if (std::holds_alternative<bool>(value)) {
     return std::get<bool>(value);
   }

--- a/engine/src/util/ConfigParser.cpp
+++ b/engine/src/util/ConfigParser.cpp
@@ -343,7 +343,7 @@ std::string ConfigParser::format(const std::set<std::string> &values) {
 }
 
 
-unsigned long ConfigObjectValue::size() {
+unsigned long ConfigObjectValue::size() const {
   return data.size();
 }
 

--- a/engine/src/util/ConfigParser.cpp
+++ b/engine/src/util/ConfigParser.cpp
@@ -56,16 +56,19 @@ ConfigSingleValue parseSingleValue(const std::string &value) {
     // if the original string contains a "." then it's a float, otherwise it's an in
     if (value.find('.') != std::string::npos) {
       return ConfigSingleValue(floatValue);
-    } else {
-      return ConfigSingleValue(static_cast<int>(std::round(floatValue)));
     }
-  } else if (value == "true" || value == "True" || value == "TRUE") {
-    return ConfigSingleValue(true);
-  } else if (value == "false" || value == "False" || value == "FALSE") {
-    return ConfigSingleValue(false);
-  } else {
-    return ConfigSingleValue(parseString(value));
+    return ConfigSingleValue(static_cast<int>(std::round(floatValue)));
   }
+
+  if (value == "true" || value == "True" || value == "TRUE") {
+    return ConfigSingleValue(true);
+  }
+
+  if (value == "false" || value == "False" || value == "FALSE") {
+    return ConfigSingleValue(false);
+  }
+
+  return ConfigSingleValue(parseString(value));
 }
 
 

--- a/engine/src/util/ConfigParser.cpp
+++ b/engine/src/util/ConfigParser.cpp
@@ -180,7 +180,7 @@ ConfigListValue parseListValue(const std::string &s) {
  * @return       The parsed member
  */
 std::variant<ConfigSingleValue, ConfigObjectValue, ConfigListValue>
-parseValue(const std::basic_string<char, std::char_traits<char>, std::allocator<char>> &value) {
+parseValue(const std::basic_string<char> &value) {
   if (value.front() == '[' && value.back() == ']')
     return parseListValue(value.substr(1, value.size() - 2));
 
@@ -333,7 +333,7 @@ std::string ConfigParser::format(const std::vector<std::string> &values) {
 
 
 std::string ConfigParser::format(const std::set<std::string> &values) {
-  std::vector<std::string> sortedValues(values.begin(), values.end());
+  std::vector sortedValues(values.begin(), values.end());
   std::sort(sortedValues.begin(), sortedValues.end());
   std::vector<std::string> quotedValues;
   quotedValues.reserve(sortedValues.size());
@@ -413,7 +413,7 @@ std::vector<std::string> ConfigListValue::asListOfStrings() const {
   std::vector<std::string> values;
   for (const auto &value: data) {
     if (std::holds_alternative<ConfigSingleValue>(value)) {
-      ConfigSingleValue single = std::get<ConfigSingleValue>(value);
+      auto single = std::get<ConfigSingleValue>(value);
       values.push_back(single.getString());
     }
   }
@@ -425,7 +425,7 @@ std::set<std::string> ConfigListValue::asSetOfStrings() const {
   std::set<std::string> values;
   for (const auto &value: data) {
     if (std::holds_alternative<ConfigSingleValue>(value)) {
-      ConfigSingleValue single = std::get<ConfigSingleValue>(value);
+      auto single = std::get<ConfigSingleValue>(value);
       values.emplace(single.getString());
     }
   }
@@ -438,7 +438,7 @@ ConfigListValue::asListOfMapsOfStrings() {
   std::vector<std::map<std::string, std::variant<std::string, std::vector<std::string>>>> maps;
   for (const auto &value: data) {
     if (std::holds_alternative<ConfigObjectValue>(value)) {
-      ConfigObjectValue object = std::get<ConfigObjectValue>(value);
+      auto object = std::get<ConfigObjectValue>(value);
       maps.emplace_back(object.asMapOfStringsOrListsOfStrings());
     }
   }

--- a/engine/src/util/StringUtils.cpp
+++ b/engine/src/util/StringUtils.cpp
@@ -47,7 +47,7 @@ std::string StringUtils::trim(const std::string &str) {
   if (first == std::string::npos)
     return "";
   const size_t last = str.find_last_not_of(" \n");
-  return str.substr(first, (last - first + 1));
+  return str.substr(first, last - first + 1);
 }
 
 

--- a/engine/src/util/StringUtils.cpp
+++ b/engine/src/util/StringUtils.cpp
@@ -53,18 +53,18 @@ std::string StringUtils::trim(const std::string &str) {
 
 std::string StringUtils::toMeme(const std::string &raw) {
   std::string result = std::regex_replace(raw, nonMeme, "");
-  std::transform(result.begin(), result.end(), result.begin(), ::toupper);// to uppercase
+  std::transform(result.begin(), result.end(), result.begin(), toupper);// to uppercase
   return result;
 }
 
 
 std::string StringUtils::toMeme(const std::string *raw, const std::string &defaultValue) {
   if (isNullOrEmpty(raw))
-    return StringUtils::toMeme(defaultValue);
+    return toMeme(defaultValue);
 
-  std::string out = StringUtils::toMeme(*raw);
+  std::string out = toMeme(*raw);
   if (out.empty())
-    return StringUtils::toMeme(defaultValue);
+    return toMeme(defaultValue);
 
   return out;
 }
@@ -72,7 +72,7 @@ std::string StringUtils::toMeme(const std::string *raw, const std::string &defau
 
 std::string StringUtils::toEvent(const std::string &raw) {
   std::string result = std::regex_replace(raw, nonEvent, "");
-  std::transform(result.begin(), result.end(), result.begin(), ::toupper);// to uppercase
+  std::transform(result.begin(), result.end(), result.begin(), toupper);// to uppercase
   return result;
 }
 
@@ -96,14 +96,14 @@ std::string StringUtils::toAlphanumeric(const std::string &raw) {
 
 std::string StringUtils::toUpperCase(const std::string &input) {
   std::string result = input;
-  std::transform(result.begin(), result.end(), result.begin(), ::toupper); // to uppercase
+  std::transform(result.begin(), result.end(), result.begin(), toupper); // to uppercase
   return result;
 }
 
 
 std::string StringUtils::toLowerCase(const std::string &input) {
   std::string result = input;
-  std::transform(result.begin(), result.end(), result.begin(), ::tolower);// to uppercase
+  std::transform(result.begin(), result.end(), result.begin(), tolower);// to uppercase
   return result;
 }
 
@@ -165,14 +165,14 @@ std::string StringUtils::toShipKey(const std::string &name) {
 
 std::string StringUtils::toLowerScored(const std::string &raw) {
   std::string scored = toScored(raw);
-  std::transform(scored.begin(), scored.end(), scored.begin(), ::tolower);
+  std::transform(scored.begin(), scored.end(), scored.begin(), tolower);
   return scored;
 }
 
 
 std::string StringUtils::toUpperScored(const std::string &raw) {
   std::string scored = toScored(raw);
-  std::transform(scored.begin(), scored.end(), scored.begin(), ::toupper);
+  std::transform(scored.begin(), scored.end(), scored.begin(), toupper);
   return scored;
 }
 

--- a/engine/src/util/ValueUtils.cpp
+++ b/engine/src/util/ValueUtils.cpp
@@ -35,16 +35,16 @@ std::mt19937 ValueUtils::gen(rd());
 float ValueUtils::eitherOr(const float d1, const float d2) {
   if (!std::isnan(d1) && d1 != 0.0f)
     return d1;
-  else
-    return d2;
+
+  return d2;
 }
 
 
 std::string ValueUtils::eitherOr(std::string s1, std::string s2) {
   if (!s1.empty())
     return s1;
-  else
-    return s2;
+
+  return s2;
 }
 
 

--- a/engine/src/util/ValueUtils.cpp
+++ b/engine/src/util/ValueUtils.cpp
@@ -79,7 +79,7 @@ std::string ValueUtils::k(const int value) {
 
 std::string ValueUtils::randomFrom(std::vector<std::string> from) {
   if (from.empty()) return "";
-  std::uniform_int_distribution<> distrib(0, static_cast<int>(from.size()) - 1);
+  std::uniform_int_distribution distrib(0, static_cast<int>(from.size()) - 1);
   const int randomIndex = distrib(gen);
   return from[randomIndex];
 }
@@ -160,7 +160,7 @@ std::vector<UUID> ValueUtils::withIdsRemoved(std::vector<UUID> fromIds, const in
   std::vector<UUID> ids = std::move(fromIds);
   for (int i = 0; i < count; i++) {
     if (!ids.empty()) {
-      std::uniform_int_distribution<> distrib(0, static_cast<int>(ids.size()) - 1);
+      std::uniform_int_distribution distrib(0, static_cast<int>(ids.size()) - 1);
       const int randomIndex = distrib(gen);
       ids.erase(ids.begin() + randomIndex);
     }
@@ -170,7 +170,7 @@ std::vector<UUID> ValueUtils::withIdsRemoved(std::vector<UUID> fromIds, const in
 
 
 std::string ValueUtils::emptyZero(const int value) {
-  return (0 != value) ? std::to_string(value) : "";
+  return 0 != value ? std::to_string(value) : "";
 }
 
 std::vector<std::string> ValueUtils::last(const int num, std::vector<std::string> list) {

--- a/engine/src/util/ValueUtils.cpp
+++ b/engine/src/util/ValueUtils.cpp
@@ -73,7 +73,7 @@ float ValueUtils::limitDecimalPrecision(const float value) {
 
 
 std::string ValueUtils::k(const int value) {
-  return std::to_string(static_cast<int>(std::floor((float) value / 1000))) + K;
+  return std::to_string(static_cast<int>(std::floor(static_cast<float>(value) / 1000))) + K;
 }
 
 

--- a/engine/test/_data/arrangements/arrangement_3.yaml
+++ b/engine/test/_data/arrangements/arrangement_3.yaml
@@ -3,7 +3,7 @@
 #
 #  This test is similar to Tests #1 and #2 except the following:
 #   - The second chord occurs at 3.0
-#   - The starting chord is in first 4cersion
+#   - The starting chord is in first version
 #
 #  XJ has a serviceable voicing algorithm https://github.com/xjmusic/xjmusic/issues/221
 ---

--- a/engine/test/_helper/ContentFixtures.cpp
+++ b/engine/test/_helper/ContentFixtures.cpp
@@ -630,7 +630,7 @@ InstrumentMeme ContentFixtures::buildInstrumentMeme(
   return instrumentMeme;
 }
 
-void ContentFixtures::setupFixtureB1(ContentEntityStore *store, bool includeBeat) {
+void ContentFixtures::setupFixtureB1(ContentEntityStore *store, const bool includeBeat) {
 
   // Project "bananas"
   project1 = buildProject("bananas");

--- a/engine/test/_helper/ContentFixtures.cpp
+++ b/engine/test/_helper/ContentFixtures.cpp
@@ -1372,7 +1372,7 @@ void ContentFixtures::generatedFixture(ContentEntityStore *store, int N) {
           store->put(buildEvent(
               &pattern,
               &trackMap[name],
-              static_cast<float>(std::floor(static_cast<float>(iPE) * static_cast<float>(total) * 4 / static_cast<float>(N))),
+              std::floor(static_cast<float>(iPE) * static_cast<float>(total) * 4 / static_cast<float>(N)),
               random(0.25f, 1.0f),
               "X",
               random(0.4f, 0.9f)));

--- a/engine/test/_helper/ContentFixtures.cpp
+++ b/engine/test/_helper/ContentFixtures.cpp
@@ -41,14 +41,14 @@ float ContentFixtures::random(const float A, const float B) {
 std::string ContentFixtures::random(std::vector<std::string> array) {
   std::random_device rd;
   std::mt19937 gen(rd());
-  std::uniform_int_distribution<> dis(0, static_cast<int>(array.size()) - 1);
+  std::uniform_int_distribution dis(0, static_cast<int>(array.size()) - 1);
   return array[dis(gen)];
 }
 
 int ContentFixtures::random(const std::vector<int> &array) {
   std::random_device rd;
   std::mt19937 gen(rd());
-  std::uniform_int_distribution<> dis(0, static_cast<int>(array.size()) - 1);
+  std::uniform_int_distribution dis(0, static_cast<int>(array.size()) - 1);
   return array[dis(gen)];
 }
 
@@ -1319,7 +1319,7 @@ void ContentFixtures::generatedFixture(ContentEntityStore *store, int N) {
   }
 
   // Generate N total Beat-type Sequences, each having N voices, and N*2 patterns comprised of N*8 events
-  std::vector<ProgramVoice> voices = std::vector<ProgramVoice>(N);
+  auto voices = std::vector<ProgramVoice>(N);
   std::unordered_map<std::string, ProgramVoiceTrack> trackMap;
   for (int i = 0; i < N; i++) {
     std::string majorMemeName = majorMemeNames[i];

--- a/engine/test/_helper/ContentFixtures.cpp
+++ b/engine/test/_helper/ContentFixtures.cpp
@@ -1171,7 +1171,7 @@ void ContentFixtures::generatedFixture(ContentEntityStore *store, int N) {
   std::vector<std::string>
       majorMemeNames = listOfUniqueRandom(N, LoremIpsum::COLORS);
   std::vector<std::string>
-      minorMemeNames = listOfUniqueRandom(static_cast<long>((double) (N >> 1)), LoremIpsum::VARIANTS);
+      minorMemeNames = listOfUniqueRandom(static_cast<long>(static_cast<double>(N >> 1)), LoremIpsum::VARIANTS);
   std::vector<std::string>
       percussiveNames = listOfUniqueRandom(N, LoremIpsum::PERCUSSIVE_NAMES);
 

--- a/engine/test/_helper/ContentFixtures.cpp
+++ b/engine/test/_helper/ContentFixtures.cpp
@@ -45,7 +45,7 @@ std::string ContentFixtures::random(std::vector<std::string> array) {
   return array[dis(gen)];
 }
 
-int ContentFixtures::random(std::vector<int> array) {
+int ContentFixtures::random(const std::vector<int> &array) {
   std::random_device rd;
   std::mt19937 gen(rd());
   std::uniform_int_distribution<> dis(0, static_cast<int>(array.size()) - 1);

--- a/engine/test/_helper/ContentFixtures.h
+++ b/engine/test/_helper/ContentFixtures.h
@@ -80,7 +80,7 @@ namespace XJ {
      @param array to get long of
      @return random long
      */
-    static int random(std::vector<int> array);
+    static int random(const std::vector<int> &array);
 
   public:
 

--- a/engine/test/_helper/SegmentFixtures.cpp
+++ b/engine/test/_helper/SegmentFixtures.cpp
@@ -100,7 +100,7 @@ Segment SegmentFixtures::buildSegment(
   segment.delta = delta;
   segment.state = state;
   segment.beginAtChainMicros =
-      static_cast<long>(id * ValueUtils::MICROS_PER_SECOND * static_cast<float>(total * ValueUtils::SECONDS_PER_MINUTE / tempo));
+      static_cast<long>(id * ValueUtils::MICROS_PER_SECOND * (total * ValueUtils::SECONDS_PER_MINUTE / tempo));
   segment.key = std::move(key);
   segment.total = total;
   segment.intensity = intensity;
@@ -111,7 +111,7 @@ Segment SegmentFixtures::buildSegment(
 
   if (hasEndSet)
     segment.durationMicros =
-        static_cast<long>(ValueUtils::MICROS_PER_SECOND * static_cast<float>(total * ValueUtils::SECONDS_PER_MINUTE / tempo));
+        static_cast<long>(ValueUtils::MICROS_PER_SECOND * (total * ValueUtils::SECONDS_PER_MINUTE / tempo));
 
   return segment;
 }

--- a/engine/test/_helper/SegmentFixtures.cpp
+++ b/engine/test/_helper/SegmentFixtures.cpp
@@ -28,25 +28,22 @@ Chain SegmentFixtures::buildChain(
 }
 
 Chain SegmentFixtures::buildChain(
-    const Project *project,
     const std::string &name,
     const Chain::Type type,
     const Chain::State state,
     const Template *tmpl) {
-  return buildChain(project, name, type, state, tmpl, StringUtils::toShipKey(name));
+  return buildChain(name, type, state, tmpl, StringUtils::toShipKey(name));
 }
 
 Chain SegmentFixtures::buildChain(
-    const Project *project,
     const Template *tmpl,
     const std::string &name,
     const Chain::Type type,
     const Chain::State state) {
-  return buildChain(project, name, type, state, tmpl, StringUtils::toShipKey(name));
+  return buildChain(name, type, state, tmpl, StringUtils::toShipKey(name));
 }
 
 Chain SegmentFixtures::buildChain(
-    const Project *project,
     std::string name,
     const Chain::Type type,
     const Chain::State state,

--- a/engine/test/_helper/SegmentFixtures.h
+++ b/engine/test/_helper/SegmentFixtures.h
@@ -10,7 +10,6 @@
 #include "xjmusic/content/ProgramSequenceBinding.h"
 #include "xjmusic/content/ProgramSequencePatternEvent.h"
 #include "xjmusic/content/ProgramVoice.h"
-#include "xjmusic/content/Project.h"
 #include "xjmusic/content/Template.h"
 #include "xjmusic/segment/Chain.h"
 #include "xjmusic/segment/Segment.h"
@@ -50,7 +49,6 @@ namespace XJ {
      * Build a chain from a template
      */
     static Chain buildChain(
-        const Project *project,
         const std::string &name,
         Chain::Type type,
         Chain::State state,
@@ -60,7 +58,6 @@ namespace XJ {
      * Build a chain from a template
      */
     static Chain buildChain(
-        const Project *project,
         const Template *tmpl,
         const std::string &name,
         Chain::Type type,
@@ -70,7 +67,6 @@ namespace XJ {
      * Build a chain from a template
      */
     static Chain buildChain(
-        const Project *project,
         std::string name,
         Chain::Type type,
         Chain::State state,

--- a/engine/test/_helper/YamlTest.cpp
+++ b/engine/test/_helper/YamlTest.cpp
@@ -44,8 +44,8 @@ void YamlTest::assertSame(const std::string &description, const int expected, co
 
 void YamlTest::assertSameNote(const std::string &description, const Note &expected, const Note &actual) {
   if (!(expected == actual)) {
-    const std::string failure = description + " — Expected: " + expected.toString(Accidental::Sharp) + " — Actual: " +
-                          actual.toString(Accidental::Sharp);
+    const std::string failure = description + " — Expected: " + expected.toString(Sharp) + " — Actual: " +
+                          actual.toString(Sharp);
     failures.insert(failure);
   }
 }
@@ -69,8 +69,8 @@ void YamlTest::assertSameNotes(const std::string &description, const std::set<st
   for (size_t i = 0; i < expectedNotes.size(); i++) {
     if (!(expectedNotes[i] == actualNotes[i])) {
       const std::string failure =
-          description + " — Expected: " + expectedNotes[i].toString(Accidental::Sharp) + " — Actual: " +
-          actualNotes[i].toString(Accidental::Sharp);
+          description + " — Expected: " + expectedNotes[i].toString(Sharp) + " — Actual: " +
+          actualNotes[i].toString(Sharp);
       failures.insert(failure);
       return;
     }

--- a/engine/test/_helper/YamlTest.h
+++ b/engine/test/_helper/YamlTest.h
@@ -33,7 +33,7 @@ protected:
    * @param filename  The name of the file to load
    * @return  The YAML node
    */
-  YAML::Node loadYaml(const std::string& prefix, const std::string& filename);
+  static YAML::Node loadYaml(const std::string& prefix, const std::string& filename);
 
 
   /**

--- a/engine/test/content/ContentEntityStoreTest.cpp
+++ b/engine/test/content/ContentEntityStoreTest.cpp
@@ -180,7 +180,7 @@ TEST_F(ContentStoreTest, FromJsonString) {
   // Load the JSON file
   std::ifstream file(CONTENT_STORE_TEST_JSON_PATH);
   ASSERT_TRUE(file.is_open());
-  std::string jsonString((std::istreambuf_iterator<char>(file)), std::istreambuf_iterator<char>());
+  std::string jsonString((std::istreambuf_iterator(file)), std::istreambuf_iterator<char>());
 
   // Deserialize a content store from a JSON file stream
   auto *subject = new ContentEntityStore(jsonString);

--- a/engine/test/content/ContentEntityStoreTest.cpp
+++ b/engine/test/content/ContentEntityStoreTest.cpp
@@ -12,7 +12,7 @@ static std::string CONTENT_STORE_TEST_JSON_PATH = "_data/content_store_test.json
 
 using namespace XJ;
 
-class ContentStoreTest : public ::testing::Test {
+class ContentStoreTest : public testing::Test {
 
 protected:
   ContentEntityStore *subject{};
@@ -51,7 +51,6 @@ protected:
   ProgramSequencePatternEvent program2_sequence_pattern1_event1;
   ProgramSequencePatternEvent program2_sequence_pattern1_event2;
 
-protected:
   void SetUp() override {
     // project
     project1 = ContentFixtures::buildProject();

--- a/engine/test/content/InstrumentTest.cpp
+++ b/engine/test/content/InstrumentTest.cpp
@@ -71,7 +71,7 @@ TEST(InstrumentTest, ToStringInstrumentType) {
 }
 
 TEST(InstrumentTest, ToStringsInstrumentType) {
-  const std::vector<Instrument::Type> types = {
+  const std::vector types = {
       Instrument::Type::Drum,
       Instrument::Type::Bass,
       Instrument::Type::Pad,

--- a/engine/test/content/TemplateConfigTest.cpp
+++ b/engine/test/content/TemplateConfigTest.cpp
@@ -8,7 +8,7 @@ using namespace XJ;
 
 TEST(TemplateConfigTest, SetFromTemplate) {
   Template input;
-  input.config = ("mixerCompressToAmplitude = 0.95");
+  input.config = "mixerCompressToAmplitude = 0.95";
 
   const TemplateConfig subject(&input);
 

--- a/engine/test/craft/ArrangementTest.cpp
+++ b/engine/test/craft/ArrangementTest.cpp
@@ -18,8 +18,8 @@
 
 // NOLINTNEXTLINE
 using ::testing::_;
-using ::testing::Return;
-using ::testing::ReturnRef;
+using testing::Return;
+using testing::ReturnRef;
 
 using namespace XJ;
 

--- a/engine/test/craft/ArrangementTest.cpp
+++ b/engine/test/craft/ArrangementTest.cpp
@@ -237,7 +237,7 @@ protected:
             throw FabricationException("Failed to locate event type " + Instrument::toString(sbType) + " position " +
                                        std::to_string(sbPosition));
           }
-          StickyBun bun = StickyBun(eventIt->id, std::vector<int>{sbSeed});
+          auto bun = StickyBun(eventIt->id, std::vector{sbSeed});
           stickyBuns.emplace_back(bun);
         }
       }

--- a/engine/test/craft/CraftTest.cpp
+++ b/engine/test/craft/CraftTest.cpp
@@ -18,8 +18,8 @@
 
 // NOLINTNEXTLINE
 using ::testing::_;
-using ::testing::Return;
-using ::testing::ReturnRef;
+using testing::Return;
+using testing::ReturnRef;
 
 using namespace XJ;
 
@@ -35,7 +35,6 @@ protected:
   Program *program1 = nullptr;
   TemplateConfig * templateConfig = nullptr;
 
-protected:
   void SetUp() override {
     sourceMaterial = new ContentEntityStore();
     segmentEntityStore = new SegmentEntityStore();

--- a/engine/test/craft/CraftTest.cpp
+++ b/engine/test/craft/CraftTest.cpp
@@ -45,8 +45,8 @@ protected:
                                                                  "C", 120.0f));
     const Template *template1 = sourceMaterial->put(ContentFixtures::buildTemplate(project1, "Test Template 1", "test1"));
     // Chain "Test Print #1" is fabricating segments
-    const Chain *chain1 = segmentEntityStore->put(SegmentFixtures::buildChain(project1, "Test Print #1", Chain::Type::Production,
-                                                                        Chain::State::Fabricate, template1));
+    const Chain *chain1 = segmentEntityStore->put(SegmentFixtures::buildChain("Test Print #1", Chain::Type::Production, Chain::State::Fabricate,
+                                                                              template1));
 
     segment0 = segmentEntityStore->put(SegmentFixtures::buildSegment(chain1, Segment::Type::Initial, 2, 128, Segment::State::Crafted, "D major",
                                                                      64, 0.73f, 120.0f, "chains-1-segments-9f7s89d8a7892", true));

--- a/engine/test/craft/CraftTest.cpp
+++ b/engine/test/craft/CraftTest.cpp
@@ -312,7 +312,7 @@ TEST_F(CraftTest, SelectGeneralAudioIntensityLayers_ThreeLayers) {
   auto result = subject->selectGeneralAudioIntensityLayers(instrument1);
 
   // Sort the result
-  std::vector<const InstrumentAudio *> resultVector(result.begin(), result.end());
+  std::vector resultVector(result.begin(), result.end());
   std::sort(resultVector.begin(), resultVector.end(), [](const InstrumentAudio *a, const InstrumentAudio *b) {
     return a->intensity < b->intensity;
   });
@@ -334,7 +334,7 @@ TEST_F(CraftTest, SelectGeneralAudioIntensityLayers_ContinueSegment) {
       ContentFixtures::buildInstrument(&library1, Instrument::Type::Percussion, Instrument::Mode::Loop,
                                        Instrument::State::Published, "Test loop audio"));
   instrument1->config = "isAudioSelectionPersistent=true";
-  InstrumentConfig instrumentConfig = InstrumentConfig(instrument1);
+  auto instrumentConfig = InstrumentConfig(instrument1);
   InstrumentAudio *instrument1audio1a = sourceMaterial->put(
       ContentFixtures::buildInstrumentAudio(instrument1, "ping", "70bpm.wav", 0.01f, 2.123f, 120.0f, 0.2f, "PERC", "X",
                                             1.0f));

--- a/engine/test/craft/background/CraftBackgroundContinueTest.cpp
+++ b/engine/test/craft/background/CraftBackgroundContinueTest.cpp
@@ -45,7 +45,7 @@ protected:
     fake->setupFixtureB3(sourceMaterial);
 
     // Chain "Test Print #1" is fabricating segments
-    chain1 = store->put(SegmentFixtures::buildChain(&fake->project1, "Test Print #1", Chain::Type::Production, Chain::State::Fabricate, &fake->template1, ""));
+    chain1 = store->put(SegmentFixtures::buildChain("Test Print #1", Chain::Type::Production, Chain::State::Fabricate, &fake->template1, ""));
     store->put(SegmentFixtures::buildSegment(
         chain1,
         Segment::Type::Initial,

--- a/engine/test/craft/background/CraftBackgroundContinueTest.cpp
+++ b/engine/test/craft/background/CraftBackgroundContinueTest.cpp
@@ -14,12 +14,12 @@
 
 // NOLINTNEXTLINE
 using ::testing::_;
-using ::testing::Return;
-using ::testing::ReturnRef;
+using testing::Return;
+using testing::ReturnRef;
 
 using namespace XJ;
 
-class CraftBackgroundContinueTest : public ::testing::Test {
+class CraftBackgroundContinueTest : public testing::Test {
 protected:
   CraftFactory *craftFactory = nullptr;
   FabricatorFactory *fabricatorFactory = nullptr;

--- a/engine/test/craft/background/CraftBackgroundInitialTest.cpp
+++ b/engine/test/craft/background/CraftBackgroundInitialTest.cpp
@@ -18,12 +18,12 @@
 
 // NOLINTNEXTLINE
 using ::testing::_;
-using ::testing::Return;
-using ::testing::ReturnRef;
+using testing::Return;
+using testing::ReturnRef;
 
 using namespace XJ;
 
-class CraftBackgroundInitialTest : public ::testing::Test {
+class CraftBackgroundInitialTest : public testing::Test {
 protected:
   CraftFactory *craftFactory = nullptr;
   FabricatorFactory *fabricatorFactory = nullptr;

--- a/engine/test/craft/background/CraftBackgroundInitialTest.cpp
+++ b/engine/test/craft/background/CraftBackgroundInitialTest.cpp
@@ -50,7 +50,6 @@ protected:
     // Chain "Print #2" has 1 initial segment in crafting state - Foundation is complete
     const auto tmpl = ContentFixtures::buildTemplate(&fake->project1, "Test");
     const auto chain2 = store->put(SegmentFixtures::buildChain(
-        &fake->project1,
         "Print #2",
         Chain::Type::Production,
         Chain::State::Fabricate,

--- a/engine/test/craft/background/CraftBackgroundNextMacroTest.cpp
+++ b/engine/test/craft/background/CraftBackgroundNextMacroTest.cpp
@@ -50,7 +50,7 @@ protected:
 
 
     // Chain "Test Print #1" has 5 total segments
-    chain1 = store->put(SegmentFixtures::buildChain(&fake->project1, "Test Print #1", Chain::Type::Production, Chain::State::Fabricate, &fake->template1, ""));
+    chain1 = store->put(SegmentFixtures::buildChain("Test Print #1", Chain::Type::Production, Chain::State::Fabricate, &fake->template1, ""));
     store->put(SegmentFixtures::buildSegment(
         chain1,
         Segment::Type::Initial,

--- a/engine/test/craft/background/CraftBackgroundNextMacroTest.cpp
+++ b/engine/test/craft/background/CraftBackgroundNextMacroTest.cpp
@@ -18,12 +18,12 @@
 
 // NOLINTNEXTLINE
 using ::testing::_;
-using ::testing::Return;
-using ::testing::ReturnRef;
+using testing::Return;
+using testing::ReturnRef;
 
 using namespace XJ;
 
-class CraftBackgroundNextMacroTest : public ::testing::Test {
+class CraftBackgroundNextMacroTest : public testing::Test {
 protected:
   CraftFactory *craftFactory = nullptr;
   FabricatorFactory *fabricatorFactory = nullptr;

--- a/engine/test/craft/background/CraftBackgroundNextMainTest.cpp
+++ b/engine/test/craft/background/CraftBackgroundNextMainTest.cpp
@@ -18,12 +18,12 @@
 
 // NOLINTNEXTLINE
 using ::testing::_;
-using ::testing::Return;
-using ::testing::ReturnRef;
+using testing::Return;
+using testing::ReturnRef;
 
 using namespace XJ;
 
-class CraftBackgroundNextMainTest : public ::testing::Test {
+class CraftBackgroundNextMainTest : public testing::Test {
 protected:
   CraftFactory *craftFactory = nullptr;
   FabricatorFactory *fabricatorFactory = nullptr;

--- a/engine/test/craft/background/CraftBackgroundNextMainTest.cpp
+++ b/engine/test/craft/background/CraftBackgroundNextMainTest.cpp
@@ -49,7 +49,7 @@ protected:
     fake->setupFixtureB3(sourceMaterial);
 
     // Chain "Test Print #1" has 5 total segments
-    chain1 = store->put(SegmentFixtures::buildChain(&fake->project1, "Test Print #1", Chain::Type::Production, Chain::State::Fabricate, &fake->template1, ""));
+    chain1 = store->put(SegmentFixtures::buildChain("Test Print #1", Chain::Type::Production, Chain::State::Fabricate, &fake->template1, ""));
     store->put(SegmentFixtures::buildSegment(
         chain1,
         0,

--- a/engine/test/craft/background/CraftBackgroundProgramVoiceContinueTest.cpp
+++ b/engine/test/craft/background/CraftBackgroundProgramVoiceContinueTest.cpp
@@ -18,12 +18,12 @@
 
 // NOLINTNEXTLINE
 using ::testing::_;
-using ::testing::Return;
-using ::testing::ReturnRef;
+using testing::Return;
+using testing::ReturnRef;
 
 using namespace XJ;
 
-class CraftBackgroundProgramVoiceContinueTest : public ::testing::Test {
+class CraftBackgroundProgramVoiceContinueTest : public testing::Test {
 protected:
   CraftFactory *craftFactory = nullptr;
   FabricatorFactory *fabricatorFactory = nullptr;

--- a/engine/test/craft/background/CraftBackgroundProgramVoiceContinueTest.cpp
+++ b/engine/test/craft/background/CraftBackgroundProgramVoiceContinueTest.cpp
@@ -51,7 +51,7 @@ protected:
     setupCustomFixtures();
 
     // Chain "Test Print #1" has 5 total segments
-    chain1 = store->put(SegmentFixtures::buildChain(&fake->project1, "Test Print #1", Chain::Type::Production, Chain::State::Fabricate, &fake->template1, ""));
+    chain1 = store->put(SegmentFixtures::buildChain("Test Print #1", Chain::Type::Production, Chain::State::Fabricate, &fake->template1, ""));
     store->put(SegmentFixtures::buildSegment(
         chain1,
         Segment::Type::Initial,

--- a/engine/test/craft/background/CraftBackgroundProgramVoiceInitialTest.cpp
+++ b/engine/test/craft/background/CraftBackgroundProgramVoiceInitialTest.cpp
@@ -18,12 +18,12 @@
 
 // NOLINTNEXTLINE
 using ::testing::_;
-using ::testing::Return;
-using ::testing::ReturnRef;
+using testing::Return;
+using testing::ReturnRef;
 
 using namespace XJ;
 
-class CraftBackgroundProgramVoiceInitialTest : public ::testing::Test {
+class CraftBackgroundProgramVoiceInitialTest : public testing::Test {
 protected:
   CraftFactory *craftFactory = nullptr;
   FabricatorFactory *fabricatorFactory = nullptr;

--- a/engine/test/craft/background/CraftBackgroundProgramVoiceNextMacroTest.cpp
+++ b/engine/test/craft/background/CraftBackgroundProgramVoiceNextMacroTest.cpp
@@ -49,7 +49,7 @@ protected:
     setupCustomFixtures();
 
     // Chain "Test Print #1" has 5 total segments
-    chain1 = store->put(SegmentFixtures::buildChain(&fake->project1, "Test Print #1", Chain::Type::Production, Chain::State::Fabricate, &fake->template1, ""));
+    chain1 = store->put(SegmentFixtures::buildChain("Test Print #1", Chain::Type::Production, Chain::State::Fabricate, &fake->template1, ""));
     store->put(SegmentFixtures::buildSegment(
         chain1,
         Segment::Type::Initial,

--- a/engine/test/craft/background/CraftBackgroundProgramVoiceNextMacroTest.cpp
+++ b/engine/test/craft/background/CraftBackgroundProgramVoiceNextMacroTest.cpp
@@ -18,12 +18,12 @@
 
 // NOLINTNEXTLINE
 using ::testing::_;
-using ::testing::Return;
-using ::testing::ReturnRef;
+using testing::Return;
+using testing::ReturnRef;
 
 using namespace XJ;
 
-class CraftBackgroundProgramVoiceNextMacroTest : public ::testing::Test {
+class CraftBackgroundProgramVoiceNextMacroTest : public testing::Test {
 protected:
   CraftFactory *craftFactory = nullptr;
   FabricatorFactory *fabricatorFactory = nullptr;

--- a/engine/test/craft/background/CraftBackgroundProgramVoiceNextMainTest.cpp
+++ b/engine/test/craft/background/CraftBackgroundProgramVoiceNextMainTest.cpp
@@ -52,7 +52,6 @@ protected:
 
     // Chain "Test Print #1" has 5 total segments
     chain1 = store->put(SegmentFixtures::buildChain(
-        &fake->project1,
         &fake->template1,
         "Test Print #1",
         Chain::Type::Production,

--- a/engine/test/craft/background/CraftBackgroundProgramVoiceNextMainTest.cpp
+++ b/engine/test/craft/background/CraftBackgroundProgramVoiceNextMainTest.cpp
@@ -18,12 +18,12 @@
 
 // NOLINTNEXTLINE
 using ::testing::_;
-using ::testing::Return;
-using ::testing::ReturnRef;
+using testing::Return;
+using testing::ReturnRef;
 
 using namespace XJ;
 
-class CraftBackgroundProgramVoiceNextMainTest : public ::testing::Test {
+class CraftBackgroundProgramVoiceNextMainTest : public testing::Test {
 protected:
   CraftFactory *craftFactory = nullptr;
   FabricatorFactory *fabricatorFactory = nullptr;

--- a/engine/test/craft/background/CraftBackground_LayeredVoicesTest.cpp
+++ b/engine/test/craft/background/CraftBackground_LayeredVoicesTest.cpp
@@ -17,15 +17,15 @@
 
 // NOLINTNEXTLINE
 using ::testing::_;
-using ::testing::Return;
-using ::testing::ReturnRef;
+using testing::Return;
+using testing::ReturnRef;
 
 using namespace XJ;
 
 /**
  Background fabrication composited of layered Patterns https://github.com/xjmusic/xjmusic/issues/267
  */
-class CraftBackground_LayeredVoicesTest : public ::testing::Test {
+class CraftBackground_LayeredVoicesTest : public testing::Test {
 protected:
   CraftFactory *craftFactory = nullptr;
   FabricatorFactory *fabricatorFactory = nullptr;

--- a/engine/test/craft/background/CraftBackground_LayeredVoicesTest.cpp
+++ b/engine/test/craft/background/CraftBackground_LayeredVoicesTest.cpp
@@ -49,7 +49,7 @@ protected:
 
 
     // Chain "Test Print #1" has 5 total segments
-    const auto chain1 = store->put(SegmentFixtures::buildChain(&fake->project1, "Test Print #1", Chain::Type::Production, Chain::State::Fabricate, &fake->template1, ""));
+    const auto chain1 = store->put(SegmentFixtures::buildChain("Test Print #1", Chain::Type::Production, Chain::State::Fabricate, &fake->template1, ""));
     store->put(SegmentFixtures::buildSegment(
         chain1,
         Segment::Type::Initial,

--- a/engine/test/craft/beat/CraftBeatContinueTest.cpp
+++ b/engine/test/craft/beat/CraftBeatContinueTest.cpp
@@ -18,12 +18,12 @@
 
 // NOLINTNEXTLINE
 using ::testing::_;
-using ::testing::Return;
-using ::testing::ReturnRef;
+using testing::Return;
+using testing::ReturnRef;
 
 using namespace XJ;
 
-class CraftBeatContinueTest : public ::testing::Test {
+class CraftBeatContinueTest : public testing::Test {
 protected:
   CraftFactory *craftFactory = nullptr;
   FabricatorFactory *fabricatorFactory = nullptr;

--- a/engine/test/craft/beat/CraftBeatContinueTest.cpp
+++ b/engine/test/craft/beat/CraftBeatContinueTest.cpp
@@ -91,7 +91,7 @@ protected:
 
    @param excludeBeatChoiceForSegment3 if desired for the purpose of this test
    */
-  void insertSegments3and4(bool excludeBeatChoiceForSegment3) {
+  void insertSegments3and4(const bool excludeBeatChoiceForSegment3) {
     // segment just crafted
     const auto segment3 = store->put(SegmentFixtures::buildSegment(
         chain1,

--- a/engine/test/craft/beat/CraftBeatContinueTest.cpp
+++ b/engine/test/craft/beat/CraftBeatContinueTest.cpp
@@ -50,7 +50,7 @@ protected:
 
 
     // Chain "Test Print #1" is fabricating segments
-    chain1 = store->put(SegmentFixtures::buildChain(&fake->project1, "Test Print #1", Chain::Type::Production, Chain::State::Fabricate, &fake->template1, ""));
+    chain1 = store->put(SegmentFixtures::buildChain("Test Print #1", Chain::Type::Production, Chain::State::Fabricate, &fake->template1, ""));
     store->put(SegmentFixtures::buildSegment(
         chain1,
         Segment::Type::Initial,

--- a/engine/test/craft/beat/CraftBeatInitialTest.cpp
+++ b/engine/test/craft/beat/CraftBeatInitialTest.cpp
@@ -18,12 +18,12 @@
 
 // NOLINTNEXTLINE
 using ::testing::_;
-using ::testing::Return;
-using ::testing::ReturnRef;
+using testing::Return;
+using testing::ReturnRef;
 
 using namespace XJ;
 
-class CraftBeatInitialTest : public ::testing::Test {
+class CraftBeatInitialTest : public testing::Test {
 protected:
   CraftFactory *craftFactory = nullptr;
   FabricatorFactory *fabricatorFactory = nullptr;

--- a/engine/test/craft/beat/CraftBeatInitialTest.cpp
+++ b/engine/test/craft/beat/CraftBeatInitialTest.cpp
@@ -50,7 +50,6 @@ protected:
     // Chain "Print #2" has 1 initial segment in crafting state - Foundation is complete
     const auto tmpl = ContentFixtures::buildTemplate(&fake->project1, "Test");
     const auto chain2 = store->put(SegmentFixtures::buildChain(
-        &fake->project1,
         "Print #2",
         Chain::Type::Production,
         Chain::State::Fabricate,

--- a/engine/test/craft/beat/CraftBeatNextMacroTest.cpp
+++ b/engine/test/craft/beat/CraftBeatNextMacroTest.cpp
@@ -90,7 +90,7 @@ protected:
 
    @param excludeBeatChoiceForSegment3 if desired for the purpose of this test
    */
-  void insertSegments3and4(bool excludeBeatChoiceForSegment3) {
+  void insertSegments3and4(const bool excludeBeatChoiceForSegment3) {
     // Chain "Test Print #1" has this segment that was just crafted
     const auto segment3 = store->put(SegmentFixtures::buildSegment(
         chain1,

--- a/engine/test/craft/beat/CraftBeatNextMacroTest.cpp
+++ b/engine/test/craft/beat/CraftBeatNextMacroTest.cpp
@@ -18,12 +18,12 @@
 
 // NOLINTNEXTLINE
 using ::testing::_;
-using ::testing::Return;
-using ::testing::ReturnRef;
+using testing::Return;
+using testing::ReturnRef;
 
 using namespace XJ;
 
-class CraftBeatNextMacroTest : public ::testing::Test {
+class CraftBeatNextMacroTest : public testing::Test {
 protected:
   CraftFactory *craftFactory = nullptr;
   FabricatorFactory *fabricatorFactory = nullptr;

--- a/engine/test/craft/beat/CraftBeatNextMacroTest.cpp
+++ b/engine/test/craft/beat/CraftBeatNextMacroTest.cpp
@@ -49,7 +49,7 @@ protected:
     fake->setupFixtureB3(sourceMaterial);
 
     // Chain "Test Print #1" has 5 total segments
-    chain1 = store->put(SegmentFixtures::buildChain(&fake->project1, "Test Print #1", Chain::Type::Production, Chain::State::Fabricate, &fake->template1, ""));
+    chain1 = store->put(SegmentFixtures::buildChain("Test Print #1", Chain::Type::Production, Chain::State::Fabricate, &fake->template1, ""));
     store->put(SegmentFixtures::buildSegment(
         chain1,
         Segment::Type::Initial,

--- a/engine/test/craft/beat/CraftBeatNextMainTest.cpp
+++ b/engine/test/craft/beat/CraftBeatNextMainTest.cpp
@@ -18,12 +18,12 @@
 
 // NOLINTNEXTLINE
 using ::testing::_;
-using ::testing::Return;
-using ::testing::ReturnRef;
+using testing::Return;
+using testing::ReturnRef;
 
 using namespace XJ;
 
-class CraftBeatNextMainTest : public ::testing::Test {
+class CraftBeatNextMainTest : public testing::Test {
 protected:
   CraftFactory *craftFactory = nullptr;
   FabricatorFactory *fabricatorFactory = nullptr;

--- a/engine/test/craft/beat/CraftBeatNextMainTest.cpp
+++ b/engine/test/craft/beat/CraftBeatNextMainTest.cpp
@@ -49,7 +49,7 @@ protected:
     fake->setupFixtureB3(sourceMaterial);
 
     // Chain "Test Print #1" has 5 total segments
-    chain1 = store->put(SegmentFixtures::buildChain(&fake->project1, "Test Print #1", Chain::Type::Production, Chain::State::Fabricate, &fake->template1, ""));
+    chain1 = store->put(SegmentFixtures::buildChain("Test Print #1", Chain::Type::Production, Chain::State::Fabricate, &fake->template1, ""));
     store->put(SegmentFixtures::buildSegment(
         chain1,
         Segment::Type::Initial,

--- a/engine/test/craft/beat/CraftBeatNextMainTest.cpp
+++ b/engine/test/craft/beat/CraftBeatNextMainTest.cpp
@@ -88,7 +88,7 @@ protected:
 
    @param excludeBeatChoiceForSegment3 if desired for the purpose of this test
    */
-  void insertSegments3and4(bool excludeBeatChoiceForSegment3) {
+  void insertSegments3and4(const bool excludeBeatChoiceForSegment3) {
     // segment just crafted
     // Testing entities for reference
     const auto segment3 = store->put(SegmentFixtures::buildSegment(

--- a/engine/test/craft/beat/CraftBeatProgramVoiceContinueTest.cpp
+++ b/engine/test/craft/beat/CraftBeatProgramVoiceContinueTest.cpp
@@ -51,7 +51,7 @@ protected:
     setupCustomFixtures();
 
     // Chain "Test Print #1" has 5 total segments
-    chain1 = store->put(SegmentFixtures::buildChain(&fake->project1, "Test Print #1", Chain::Type::Production, Chain::State::Fabricate, &fake->template1, ""));
+    chain1 = store->put(SegmentFixtures::buildChain("Test Print #1", Chain::Type::Production, Chain::State::Fabricate, &fake->template1, ""));
     store->put(SegmentFixtures::buildSegment(
         chain1,
         Segment::Type::Initial,

--- a/engine/test/craft/beat/CraftBeatProgramVoiceContinueTest.cpp
+++ b/engine/test/craft/beat/CraftBeatProgramVoiceContinueTest.cpp
@@ -18,12 +18,12 @@
 
 // NOLINTNEXTLINE
 using ::testing::_;
-using ::testing::Return;
-using ::testing::ReturnRef;
+using testing::Return;
+using testing::ReturnRef;
 
 using namespace XJ;
 
-class CraftBeatProgramVoiceContinueTest : public ::testing::Test {
+class CraftBeatProgramVoiceContinueTest : public testing::Test {
 protected:
   CraftFactory *craftFactory = nullptr;
   FabricatorFactory *fabricatorFactory = nullptr;

--- a/engine/test/craft/beat/CraftBeatProgramVoiceContinueTest.cpp
+++ b/engine/test/craft/beat/CraftBeatProgramVoiceContinueTest.cpp
@@ -107,7 +107,7 @@ protected:
 
    @param excludeBeatChoiceForSegment3 if desired for the purpose of this test
    */
-  void insertSegments3and4(bool excludeBeatChoiceForSegment3) {
+  void insertSegments3and4(const bool excludeBeatChoiceForSegment3) {
     // segment just crafted
     // Testing entities for reference
     const auto segment3 = store->put(SegmentFixtures::buildSegment(

--- a/engine/test/craft/beat/CraftBeatProgramVoiceInitialTest.cpp
+++ b/engine/test/craft/beat/CraftBeatProgramVoiceInitialTest.cpp
@@ -18,12 +18,12 @@
 
 // NOLINTNEXTLINE
 using ::testing::_;
-using ::testing::Return;
-using ::testing::ReturnRef;
+using testing::Return;
+using testing::ReturnRef;
 
 using namespace XJ;
 
-class CraftBeatProgramVoiceInitialTest : public ::testing::Test {
+class CraftBeatProgramVoiceInitialTest : public testing::Test {
 protected:
   CraftFactory *craftFactory = nullptr;
   FabricatorFactory *fabricatorFactory = nullptr;

--- a/engine/test/craft/beat/CraftBeatProgramVoiceInitialTest.cpp
+++ b/engine/test/craft/beat/CraftBeatProgramVoiceInitialTest.cpp
@@ -51,7 +51,6 @@ protected:
     // Chain "Print #2" has 1 initial segment in crafting state - Foundation is complete
     const auto tmpl = ContentFixtures::buildTemplate(&fake->project1, "Tests");
     chain2 = store->put(SegmentFixtures::buildChain(
-        &fake->project1,
         "Print #2",
         Chain::Type::Production,
         Chain::State::Fabricate,

--- a/engine/test/craft/beat/CraftBeatProgramVoiceNextMacroTest.cpp
+++ b/engine/test/craft/beat/CraftBeatProgramVoiceNextMacroTest.cpp
@@ -109,7 +109,7 @@ protected:
 
    @param excludeBeatChoiceForSegment3 if desired for the purpose of this test
    */
-  void insertSegments3and4(bool excludeBeatChoiceForSegment3) {
+  void insertSegments3and4(const bool excludeBeatChoiceForSegment3) {
     // Chain "Test Print #1" has this segment that was just crafted
     const auto segment3 = store->put(SegmentFixtures::buildSegment(
         chain1,

--- a/engine/test/craft/beat/CraftBeatProgramVoiceNextMacroTest.cpp
+++ b/engine/test/craft/beat/CraftBeatProgramVoiceNextMacroTest.cpp
@@ -19,12 +19,12 @@
 
 // NOLINTNEXTLINE
 using ::testing::_;
-using ::testing::Return;
-using ::testing::ReturnRef;
+using testing::Return;
+using testing::ReturnRef;
 
 using namespace XJ;
 
-class CraftBeatProgramVoiceNextMacroTest : public ::testing::Test {
+class CraftBeatProgramVoiceNextMacroTest : public testing::Test {
 protected:
   CraftFactory *craftFactory = nullptr;
   FabricatorFactory *fabricatorFactory = nullptr;

--- a/engine/test/craft/beat/CraftBeatProgramVoiceNextMacroTest.cpp
+++ b/engine/test/craft/beat/CraftBeatProgramVoiceNextMacroTest.cpp
@@ -52,7 +52,7 @@ protected:
     setupCustomFixtures();
 
     // Chain "Test Print #1" has 5 total segments
-    chain1 = store->put(SegmentFixtures::buildChain(&fake->project1, "Test Print #1", Chain::Type::Production, Chain::State::Fabricate, &fake->template1, ""));
+    chain1 = store->put(SegmentFixtures::buildChain("Test Print #1", Chain::Type::Production, Chain::State::Fabricate, &fake->template1, ""));
     store->put(SegmentFixtures::buildSegment(
         chain1,
         Segment::Type::Initial,

--- a/engine/test/craft/beat/CraftBeatProgramVoiceNextMainTest.cpp
+++ b/engine/test/craft/beat/CraftBeatProgramVoiceNextMainTest.cpp
@@ -18,12 +18,12 @@
 
 // NOLINTNEXTLINE
 using ::testing::_;
-using ::testing::Return;
-using ::testing::ReturnRef;
+using testing::Return;
+using testing::ReturnRef;
 
 using namespace XJ;
 
-class CraftBeatProgramVoiceNextMainTest : public ::testing::Test {
+class CraftBeatProgramVoiceNextMainTest : public testing::Test {
 protected:
   CraftFactory *craftFactory = nullptr;
   FabricatorFactory *fabricatorFactory = nullptr;

--- a/engine/test/craft/beat/CraftBeatProgramVoiceNextMainTest.cpp
+++ b/engine/test/craft/beat/CraftBeatProgramVoiceNextMainTest.cpp
@@ -131,7 +131,7 @@ protected:
 
    @param excludeBeatChoiceForSegment3 if desired for the purpose of this test
    */
-  void insertSegments3and4(bool excludeBeatChoiceForSegment3) {
+  void insertSegments3and4(const bool excludeBeatChoiceForSegment3) {
     // segment just crafted
     // Testing entities for reference
     const auto segment3 = store->put(SegmentFixtures::buildSegment(

--- a/engine/test/craft/beat/CraftBeatProgramVoiceNextMainTest.cpp
+++ b/engine/test/craft/beat/CraftBeatProgramVoiceNextMainTest.cpp
@@ -202,7 +202,7 @@ TEST_F(CraftBeatProgramVoiceNextMainTest, CraftBeatVoiceNextMain) {
 
   craftFactory->beat(fabricator).doWork();
 
-  std::set<const SegmentChoice*> choices = {fabricator->getCurrentBeatChoice().value()};
+  std::set choices = {fabricator->getCurrentBeatChoice().value()};
   ASSERT_FALSE(fabricator->getArrangements(choices).empty());
 
 

--- a/engine/test/craft/beat/CraftBeatProgramVoiceNextMainTest.cpp
+++ b/engine/test/craft/beat/CraftBeatProgramVoiceNextMainTest.cpp
@@ -52,7 +52,6 @@ protected:
 
     // Chain "Test Print #1" has 5 total segments
     chain1 = store->put(SegmentFixtures::buildChain(
-        &fake->project1,
         &fake->template1,
         "Test Print #1",
         Chain::Type::Production,

--- a/engine/test/craft/beat/CraftBeat_LayeredVoicesTest.cpp
+++ b/engine/test/craft/beat/CraftBeat_LayeredVoicesTest.cpp
@@ -50,7 +50,7 @@ protected:
     setupCustomFixtures();
 
     // Chain "Test Print #1" has 5 total segments
-    const auto chain1 = store->put(SegmentFixtures::buildChain(&fake->project1, "Test Print #1", Chain::Type::Production, Chain::State::Fabricate, &fake->template1, ""));
+    const auto chain1 = store->put(SegmentFixtures::buildChain("Test Print #1", Chain::Type::Production, Chain::State::Fabricate, &fake->template1, ""));
     store->put(SegmentFixtures::buildSegment(
         chain1,
         Segment::Type::Initial,

--- a/engine/test/craft/beat/CraftBeat_LayeredVoicesTest.cpp
+++ b/engine/test/craft/beat/CraftBeat_LayeredVoicesTest.cpp
@@ -17,12 +17,12 @@
 
 // NOLINTNEXTLINE
 using ::testing::_;
-using ::testing::Return;
-using ::testing::ReturnRef;
+using testing::Return;
+using testing::ReturnRef;
 
 using namespace XJ;
 
-class CraftBeat_LayeredVoicesTest : public ::testing::Test {
+class CraftBeat_LayeredVoicesTest : public testing::Test {
 protected:
   CraftFactory *craftFactory = nullptr;
   FabricatorFactory *fabricatorFactory = nullptr;

--- a/engine/test/craft/detail/CraftDetailContinueTest.cpp
+++ b/engine/test/craft/detail/CraftDetailContinueTest.cpp
@@ -96,7 +96,7 @@ protected:
 
    @param excludeDetailChoiceForSegment3 if desired for the purpose of this test
    */
-  void insertSegments3and4(bool excludeDetailChoiceForSegment3) {
+  void insertSegments3and4(const bool excludeDetailChoiceForSegment3) {
     // segment just crafted
     const auto segment3 = store->put(SegmentFixtures::buildSegment(chain1,
                                                                    Segment::Type::Continue,

--- a/engine/test/craft/detail/CraftDetailContinueTest.cpp
+++ b/engine/test/craft/detail/CraftDetailContinueTest.cpp
@@ -18,12 +18,12 @@
 
 // NOLINTNEXTLINE
 using ::testing::_;
-using ::testing::Return;
-using ::testing::ReturnRef;
+using testing::Return;
+using testing::ReturnRef;
 
 using namespace XJ;
 
-class CraftDetailContinueTest : public ::testing::Test {
+class CraftDetailContinueTest : public testing::Test {
 protected:
   CraftFactory *craftFactory = nullptr;
   FabricatorFactory *fabricatorFactory = nullptr;

--- a/engine/test/craft/detail/CraftDetailContinueTest.cpp
+++ b/engine/test/craft/detail/CraftDetailContinueTest.cpp
@@ -50,7 +50,6 @@ protected:
 
     // Chain "Test Print #1" is fabricating segments
     chain1 = store->put(SegmentFixtures::buildChain(
-        &fake->project1,
         &fake->template1,
         "Test Print #1",
         Chain::Type::Production,

--- a/engine/test/craft/detail/CraftDetailInitialTest.cpp
+++ b/engine/test/craft/detail/CraftDetailInitialTest.cpp
@@ -50,7 +50,6 @@ protected:
 
     // Chain "Print #2" has 1 initial segment in crafting state - Foundation is complete
     const auto chain2 = store->put(SegmentFixtures::buildChain(
-        &fake->project1,
         &fake->template1,
         "Print #2",
         Chain::Type::Production,

--- a/engine/test/craft/detail/CraftDetailInitialTest.cpp
+++ b/engine/test/craft/detail/CraftDetailInitialTest.cpp
@@ -18,12 +18,12 @@
 
 // NOLINTNEXTLINE
 using ::testing::_;
-using ::testing::Return;
-using ::testing::ReturnRef;
+using testing::Return;
+using testing::ReturnRef;
 
 using namespace XJ;
 
-class CraftDetailInitialTest : public ::testing::Test {
+class CraftDetailInitialTest : public testing::Test {
 protected:
   CraftFactory *craftFactory = nullptr;
   FabricatorFactory *fabricatorFactory = nullptr;

--- a/engine/test/craft/detail/CraftDetailNextMacroTest.cpp
+++ b/engine/test/craft/detail/CraftDetailNextMacroTest.cpp
@@ -51,7 +51,7 @@ protected:
 
 
     // Chain "Test Print #1" has 5 total segments
-    chain1 = store->put(SegmentFixtures::buildChain(&fake->project1, "Test Print #1", Chain::Type::Production, Chain::State::Fabricate, &fake->template1, ""));
+    chain1 = store->put(SegmentFixtures::buildChain("Test Print #1", Chain::Type::Production, Chain::State::Fabricate, &fake->template1, ""));
     store->put(SegmentFixtures::buildSegment(
         chain1,
         Segment::Type::Initial,

--- a/engine/test/craft/detail/CraftDetailNextMacroTest.cpp
+++ b/engine/test/craft/detail/CraftDetailNextMacroTest.cpp
@@ -92,7 +92,7 @@ protected:
 
    @param excludeDetailChoiceForSegment3 if desired for the purpose of this test
    */
-  void insertSegments3and4(bool excludeDetailChoiceForSegment3) {
+  void insertSegments3and4(const bool excludeDetailChoiceForSegment3) {
     // Chain "Test Print #1" has this segment that was just crafted
     const auto segment3 = store->put(SegmentFixtures::buildSegment(
         chain1,

--- a/engine/test/craft/detail/CraftDetailNextMacroTest.cpp
+++ b/engine/test/craft/detail/CraftDetailNextMacroTest.cpp
@@ -18,12 +18,12 @@
 
 // NOLINTNEXTLINE
 using ::testing::_;
-using ::testing::Return;
-using ::testing::ReturnRef;
+using testing::Return;
+using testing::ReturnRef;
 
 using namespace XJ;
 
-class CraftDetailNextMacroTest : public ::testing::Test {
+class CraftDetailNextMacroTest : public testing::Test {
 protected:
   CraftFactory *craftFactory = nullptr;
   FabricatorFactory *fabricatorFactory = nullptr;

--- a/engine/test/craft/detail/CraftDetailNextMainTest.cpp
+++ b/engine/test/craft/detail/CraftDetailNextMainTest.cpp
@@ -50,7 +50,7 @@ protected:
     fake->setupFixtureB4_DetailBass(sourceMaterial);
 
     // Chain "Test Print #1" has 5 total segments
-    chain1 = store->put(SegmentFixtures::buildChain(&fake->project1, "Test Print #1", Chain::Type::Production, Chain::State::Fabricate, &fake->template1, ""));
+    chain1 = store->put(SegmentFixtures::buildChain("Test Print #1", Chain::Type::Production, Chain::State::Fabricate, &fake->template1, ""));
     store->put(SegmentFixtures::buildSegment(
         chain1,
         Segment::Type::Initial,

--- a/engine/test/craft/detail/CraftDetailNextMainTest.cpp
+++ b/engine/test/craft/detail/CraftDetailNextMainTest.cpp
@@ -18,12 +18,12 @@
 
 // NOLINTNEXTLINE
 using ::testing::_;
-using ::testing::Return;
-using ::testing::ReturnRef;
+using testing::Return;
+using testing::ReturnRef;
 
 using namespace XJ;
 
-class CraftDetailNextMainTest : public ::testing::Test {
+class CraftDetailNextMainTest : public testing::Test {
 protected:
   CraftFactory *craftFactory = nullptr;
   FabricatorFactory *fabricatorFactory = nullptr;

--- a/engine/test/craft/detail/CraftDetailNextMainTest.cpp
+++ b/engine/test/craft/detail/CraftDetailNextMainTest.cpp
@@ -91,7 +91,7 @@ protected:
 
    @param excludeDetailChoiceForSegment3 if desired for the purpose of this test
    */
-  void insertSegments3and4(bool excludeDetailChoiceForSegment3) {
+  void insertSegments3and4(const bool excludeDetailChoiceForSegment3) {
     // segment just crafted
     // Testing entities for reference
     const auto segment3 = store->put(SegmentFixtures::buildSegment(

--- a/engine/test/craft/detail/CraftDetailProgramVoiceContinueTest.cpp
+++ b/engine/test/craft/detail/CraftDetailProgramVoiceContinueTest.cpp
@@ -18,12 +18,12 @@
 
 // NOLINTNEXTLINE
 using ::testing::_;
-using ::testing::Return;
-using ::testing::ReturnRef;
+using testing::Return;
+using testing::ReturnRef;
 
 using namespace XJ;
 
-class CraftDetailProgramVoiceContinueTest : public ::testing::Test {
+class CraftDetailProgramVoiceContinueTest : public testing::Test {
 protected:
   CraftFactory *craftFactory = nullptr;
   FabricatorFactory *fabricatorFactory = nullptr;

--- a/engine/test/craft/detail/CraftDetailProgramVoiceContinueTest.cpp
+++ b/engine/test/craft/detail/CraftDetailProgramVoiceContinueTest.cpp
@@ -49,7 +49,7 @@ protected:
     fake->setupFixtureB4_DetailBass(sourceMaterial);
 
     // Chain "Test Print #1" has 5 total segments
-    chain1 = store->put(SegmentFixtures::buildChain(&fake->project1, "Test Print #1", Chain::Type::Production, Chain::State::Fabricate, &fake->template1, ""));
+    chain1 = store->put(SegmentFixtures::buildChain("Test Print #1", Chain::Type::Production, Chain::State::Fabricate, &fake->template1, ""));
     store->put(SegmentFixtures::buildSegment(
         chain1,
         Segment::Type::Initial,

--- a/engine/test/craft/detail/CraftDetailProgramVoiceContinueTest.cpp
+++ b/engine/test/craft/detail/CraftDetailProgramVoiceContinueTest.cpp
@@ -91,7 +91,7 @@ protected:
 
    @param excludeDetailChoiceForSegment3 if desired for the purpose of this test
    */
-  void insertSegments3and4(bool excludeDetailChoiceForSegment3) {
+  void insertSegments3and4(const bool excludeDetailChoiceForSegment3) {
     // segment just crafted
     // Testing entities for reference
     const auto segment3 = store->put(SegmentFixtures::buildSegment(

--- a/engine/test/craft/detail/CraftDetailProgramVoiceInitialTest.cpp
+++ b/engine/test/craft/detail/CraftDetailProgramVoiceInitialTest.cpp
@@ -51,7 +51,6 @@ protected:
 
     // Chain "Print #2" has 1 initial segment in crafting state - Foundation is complete
     chain2 = store->put(SegmentFixtures::buildChain(
-        &fake->project1,
         &fake->template1,
         "Print #2",
         Chain::Type::Production,

--- a/engine/test/craft/detail/CraftDetailProgramVoiceInitialTest.cpp
+++ b/engine/test/craft/detail/CraftDetailProgramVoiceInitialTest.cpp
@@ -18,12 +18,12 @@
 
 // NOLINTNEXTLINE
 using ::testing::_;
-using ::testing::Return;
-using ::testing::ReturnRef;
+using testing::Return;
+using testing::ReturnRef;
 
 using namespace XJ;
 
-class CraftDetailProgramVoiceInitialTest : public ::testing::Test {
+class CraftDetailProgramVoiceInitialTest : public testing::Test {
 protected:
   CraftFactory *craftFactory = nullptr;
   FabricatorFactory *fabricatorFactory = nullptr;

--- a/engine/test/craft/detail/CraftDetailProgramVoiceNextMacroTest.cpp
+++ b/engine/test/craft/detail/CraftDetailProgramVoiceNextMacroTest.cpp
@@ -90,7 +90,7 @@ protected:
 
    @param excludeDetailChoiceForSegment3 if desired for the purpose of this test
    */
-  void insertSegments3and4(bool excludeDetailChoiceForSegment3) {
+  void insertSegments3and4(const bool excludeDetailChoiceForSegment3) {
     // Chain "Test Print #1" has this segment that was just crafted
     const auto segment3 = store->put(SegmentFixtures::buildSegment(
         chain1,

--- a/engine/test/craft/detail/CraftDetailProgramVoiceNextMacroTest.cpp
+++ b/engine/test/craft/detail/CraftDetailProgramVoiceNextMacroTest.cpp
@@ -18,12 +18,12 @@
 
 // NOLINTNEXTLINE
 using ::testing::_;
-using ::testing::Return;
-using ::testing::ReturnRef;
+using testing::Return;
+using testing::ReturnRef;
 
 using namespace XJ;
 
-class CraftDetailProgramVoiceNextMacroTest : public ::testing::Test {
+class CraftDetailProgramVoiceNextMacroTest : public testing::Test {
 protected:
   CraftFactory *craftFactory = nullptr;
   FabricatorFactory *fabricatorFactory = nullptr;

--- a/engine/test/craft/detail/CraftDetailProgramVoiceNextMacroTest.cpp
+++ b/engine/test/craft/detail/CraftDetailProgramVoiceNextMacroTest.cpp
@@ -49,7 +49,7 @@ protected:
     fake->setupFixtureB4_DetailBass(sourceMaterial);
 
     // Chain "Test Print #1" has 5 total segments
-    chain1 = store->put(SegmentFixtures::buildChain(&fake->project1, "Test Print #1", Chain::Type::Production, Chain::State::Fabricate, &fake->template1, ""));
+    chain1 = store->put(SegmentFixtures::buildChain("Test Print #1", Chain::Type::Production, Chain::State::Fabricate, &fake->template1, ""));
     store->put(SegmentFixtures::buildSegment(
         chain1,
         Segment::Type::Initial,

--- a/engine/test/craft/detail/CraftDetailProgramVoiceNextMainTest.cpp
+++ b/engine/test/craft/detail/CraftDetailProgramVoiceNextMainTest.cpp
@@ -50,7 +50,7 @@ protected:
 
 
     // Chain "Test Print #1" has 5 total segments
-    chain1 = store->put(SegmentFixtures::buildChain(&fake->project1, "Test Print #1", Chain::Type::Production, Chain::State::Fabricate, &fake->template1, ""));
+    chain1 = store->put(SegmentFixtures::buildChain("Test Print #1", Chain::Type::Production, Chain::State::Fabricate, &fake->template1, ""));
     store->put(SegmentFixtures::buildSegment(
         chain1,
         Segment::Type::Initial,

--- a/engine/test/craft/detail/CraftDetailProgramVoiceNextMainTest.cpp
+++ b/engine/test/craft/detail/CraftDetailProgramVoiceNextMainTest.cpp
@@ -92,7 +92,7 @@ protected:
 
    @param excludeDetailChoiceForSegment3 if desired for the purpose of this test
    */
-  void insertSegments3and4(bool excludeDetailChoiceForSegment3) {
+  void insertSegments3and4(const bool excludeDetailChoiceForSegment3) {
     // segment just crafted
     // Testing entities for reference
     const auto segment3 = store->put(SegmentFixtures::buildSegment(

--- a/engine/test/craft/detail/CraftDetailProgramVoiceNextMainTest.cpp
+++ b/engine/test/craft/detail/CraftDetailProgramVoiceNextMainTest.cpp
@@ -18,12 +18,12 @@
 
 // NOLINTNEXTLINE
 using ::testing::_;
-using ::testing::Return;
-using ::testing::ReturnRef;
+using testing::Return;
+using testing::ReturnRef;
 
 using namespace XJ;
 
-class CraftDetailProgramVoiceNextMainTest : public ::testing::Test {
+class CraftDetailProgramVoiceNextMainTest : public testing::Test {
 protected:
   CraftFactory *craftFactory = nullptr;
   FabricatorFactory *fabricatorFactory = nullptr;

--- a/engine/test/craft/detail_hook/CraftHookContinueTest.cpp
+++ b/engine/test/craft/detail_hook/CraftHookContinueTest.cpp
@@ -18,12 +18,12 @@
 
 // NOLINTNEXTLINE
 using ::testing::_;
-using ::testing::Return;
-using ::testing::ReturnRef;
+using testing::Return;
+using testing::ReturnRef;
 
 using namespace XJ;
 
-class CraftHookContinueTest : public ::testing::Test {
+class CraftHookContinueTest : public testing::Test {
 protected:
   CraftFactory *craftFactory = nullptr;
   FabricatorFactory *fabricatorFactory = nullptr;

--- a/engine/test/craft/detail_hook/CraftHookContinueTest.cpp
+++ b/engine/test/craft/detail_hook/CraftHookContinueTest.cpp
@@ -50,7 +50,7 @@ protected:
 
 
     // Chain "Test Print #1" is fabricating segments
-    chain1 = store->put(SegmentFixtures::buildChain(&fake->project1, "Test Print #1", Chain::Type::Production, Chain::State::Fabricate, &fake->template1, ""));
+    chain1 = store->put(SegmentFixtures::buildChain("Test Print #1", Chain::Type::Production, Chain::State::Fabricate, &fake->template1, ""));
     store->put(SegmentFixtures::buildSegment(
         chain1,
         Segment::Type::Initial,

--- a/engine/test/craft/detail_hook/CraftHookContinueTest.cpp
+++ b/engine/test/craft/detail_hook/CraftHookContinueTest.cpp
@@ -92,7 +92,7 @@ protected:
 
    @param excludeHookChoiceForSegment3 if desired for the purpose of this test
    */
-  void insertSegments3and4(bool excludeHookChoiceForSegment3) {
+  void insertSegments3and4(const bool excludeHookChoiceForSegment3) {
     // segment just crafted
     const auto segment3 = store->put(SegmentFixtures::buildSegment(
         chain1,

--- a/engine/test/craft/detail_hook/CraftHookInitialTest.cpp
+++ b/engine/test/craft/detail_hook/CraftHookInitialTest.cpp
@@ -18,12 +18,12 @@
 
 // NOLINTNEXTLINE
 using ::testing::_;
-using ::testing::Return;
-using ::testing::ReturnRef;
+using testing::Return;
+using testing::ReturnRef;
 
 using namespace XJ;
 
-class CraftHookInitialTest : public ::testing::Test {
+class CraftHookInitialTest : public testing::Test {
 protected:
   CraftFactory *craftFactory = nullptr;
   FabricatorFactory *fabricatorFactory = nullptr;

--- a/engine/test/craft/detail_hook/CraftHookInitialTest.cpp
+++ b/engine/test/craft/detail_hook/CraftHookInitialTest.cpp
@@ -50,7 +50,6 @@ protected:
     // Chain "Print #2" has 1 initial segment in crafting state - Foundation is complete
     const auto tmpl = ContentFixtures::buildTemplate(&fake->project1, "Test");
     const auto chain2 = store->put(SegmentFixtures::buildChain(
-        &fake->project1,
         "Print #2",
         Chain::Type::Production,
         Chain::State::Fabricate,

--- a/engine/test/craft/detail_hook/CraftHookNextMacroTest.cpp
+++ b/engine/test/craft/detail_hook/CraftHookNextMacroTest.cpp
@@ -18,12 +18,12 @@
 
 // NOLINTNEXTLINE
 using ::testing::_;
-using ::testing::Return;
-using ::testing::ReturnRef;
+using testing::Return;
+using testing::ReturnRef;
 
 using namespace XJ;
 
-class CraftHookNextMacroTest : public ::testing::Test {
+class CraftHookNextMacroTest : public testing::Test {
 protected:
   CraftFactory *craftFactory = nullptr;
   FabricatorFactory *fabricatorFactory = nullptr;

--- a/engine/test/craft/detail_hook/CraftHookNextMacroTest.cpp
+++ b/engine/test/craft/detail_hook/CraftHookNextMacroTest.cpp
@@ -49,7 +49,7 @@ protected:
     fake->setupFixtureB3(sourceMaterial);
 
     // Chain "Test Print #1" has 5 total segments
-    chain1 = store->put(SegmentFixtures::buildChain(&fake->project1, "Test Print #1", Chain::Type::Production, Chain::State::Fabricate, &fake->template1, ""));
+    chain1 = store->put(SegmentFixtures::buildChain("Test Print #1", Chain::Type::Production, Chain::State::Fabricate, &fake->template1, ""));
     store->put(SegmentFixtures::buildSegment(
         chain1,
         Segment::Type::Initial,

--- a/engine/test/craft/detail_hook/CraftHookNextMainTest.cpp
+++ b/engine/test/craft/detail_hook/CraftHookNextMainTest.cpp
@@ -50,7 +50,7 @@ protected:
 
 
     // Chain "Test Print #1" has 5 total segments
-    chain1 = store->put(SegmentFixtures::buildChain(&fake->project1, "Test Print #1", Chain::Type::Production, Chain::State::Fabricate, &fake->template1, ""));
+    chain1 = store->put(SegmentFixtures::buildChain("Test Print #1", Chain::Type::Production, Chain::State::Fabricate, &fake->template1, ""));
     store->put(SegmentFixtures::buildSegment(
         chain1,
         0,

--- a/engine/test/craft/detail_hook/CraftHookNextMainTest.cpp
+++ b/engine/test/craft/detail_hook/CraftHookNextMainTest.cpp
@@ -18,12 +18,12 @@
 
 // NOLINTNEXTLINE
 using ::testing::_;
-using ::testing::Return;
-using ::testing::ReturnRef;
+using testing::Return;
+using testing::ReturnRef;
 
 using namespace XJ;
 
-class CraftHookNextMainTest : public ::testing::Test {
+class CraftHookNextMainTest : public testing::Test {
 protected:
   CraftFactory *craftFactory = nullptr;
   FabricatorFactory *fabricatorFactory = nullptr;

--- a/engine/test/craft/detail_hook/CraftHookProgramVoiceContinueTest.cpp
+++ b/engine/test/craft/detail_hook/CraftHookProgramVoiceContinueTest.cpp
@@ -51,7 +51,7 @@ protected:
     setupCustomFixtures();
 
     // Chain "Test Print #1" has 5 total segments
-    chain1 = store->put(SegmentFixtures::buildChain(&fake->project1, "Test Print #1", Chain::Type::Production, Chain::State::Fabricate, &fake->template1, ""));
+    chain1 = store->put(SegmentFixtures::buildChain("Test Print #1", Chain::Type::Production, Chain::State::Fabricate, &fake->template1, ""));
     store->put(SegmentFixtures::buildSegment(
         chain1,
         Segment::Type::Initial,

--- a/engine/test/craft/detail_hook/CraftHookProgramVoiceContinueTest.cpp
+++ b/engine/test/craft/detail_hook/CraftHookProgramVoiceContinueTest.cpp
@@ -18,12 +18,12 @@
 
 // NOLINTNEXTLINE
 using ::testing::_;
-using ::testing::Return;
-using ::testing::ReturnRef;
+using testing::Return;
+using testing::ReturnRef;
 
 using namespace XJ;
 
-class CraftHookProgramVoiceContinueTest : public ::testing::Test {
+class CraftHookProgramVoiceContinueTest : public testing::Test {
 protected:
   CraftFactory *craftFactory = nullptr;
   FabricatorFactory *fabricatorFactory = nullptr;

--- a/engine/test/craft/detail_hook/CraftHookProgramVoiceInitialTest.cpp
+++ b/engine/test/craft/detail_hook/CraftHookProgramVoiceInitialTest.cpp
@@ -18,12 +18,12 @@
 
 // NOLINTNEXTLINE
 using ::testing::_;
-using ::testing::Return;
-using ::testing::ReturnRef;
+using testing::Return;
+using testing::ReturnRef;
 
 using namespace XJ;
 
-class CraftHookProgramVoiceInitialTest : public ::testing::Test {
+class CraftHookProgramVoiceInitialTest : public testing::Test {
 protected:
   CraftFactory *craftFactory = nullptr;
   FabricatorFactory *fabricatorFactory = nullptr;

--- a/engine/test/craft/detail_hook/CraftHookProgramVoiceNextMacroTest.cpp
+++ b/engine/test/craft/detail_hook/CraftHookProgramVoiceNextMacroTest.cpp
@@ -107,7 +107,7 @@ protected:
 
    @param excludeHookChoiceForSegment3 if desired for the purpose of this test
    */
-  void insertSegments3and4(bool excludeHookChoiceForSegment3) {
+  void insertSegments3and4(const bool excludeHookChoiceForSegment3) {
     // Chain "Test Print #1" has this segment that was just crafted
     const auto segment3 = store->put(SegmentFixtures::buildSegment(
         chain1,

--- a/engine/test/craft/detail_hook/CraftHookProgramVoiceNextMacroTest.cpp
+++ b/engine/test/craft/detail_hook/CraftHookProgramVoiceNextMacroTest.cpp
@@ -18,12 +18,12 @@
 
 // NOLINTNEXTLINE
 using ::testing::_;
-using ::testing::Return;
-using ::testing::ReturnRef;
+using testing::Return;
+using testing::ReturnRef;
 
 using namespace XJ;
 
-class CraftHookProgramVoiceNextMacroTest : public ::testing::Test {
+class CraftHookProgramVoiceNextMacroTest : public testing::Test {
 protected:
   CraftFactory *craftFactory = nullptr;
   FabricatorFactory *fabricatorFactory = nullptr;

--- a/engine/test/craft/detail_hook/CraftHookProgramVoiceNextMacroTest.cpp
+++ b/engine/test/craft/detail_hook/CraftHookProgramVoiceNextMacroTest.cpp
@@ -51,7 +51,7 @@ protected:
     setupCustomFixtures();
 
     // Chain "Test Print #1" has 5 total segments
-    chain1 = store->put(SegmentFixtures::buildChain(&fake->project1, "Test Print #1", Chain::Type::Production, Chain::State::Fabricate, &fake->template1, ""));
+    chain1 = store->put(SegmentFixtures::buildChain("Test Print #1", Chain::Type::Production, Chain::State::Fabricate, &fake->template1, ""));
     store->put(SegmentFixtures::buildSegment(
         chain1,
         Segment::Type::Initial,

--- a/engine/test/craft/detail_hook/CraftHookProgramVoiceNextMainTest.cpp
+++ b/engine/test/craft/detail_hook/CraftHookProgramVoiceNextMainTest.cpp
@@ -52,7 +52,6 @@ protected:
 
     // Chain "Test Print #1" has 5 total segments
     chain1 = store->put(SegmentFixtures::buildChain(
-        &fake->project1,
         &fake->template1,
         "Test Print #1",
         Chain::Type::Production,

--- a/engine/test/craft/detail_hook/CraftHookProgramVoiceNextMainTest.cpp
+++ b/engine/test/craft/detail_hook/CraftHookProgramVoiceNextMainTest.cpp
@@ -18,12 +18,12 @@
 
 // NOLINTNEXTLINE
 using ::testing::_;
-using ::testing::Return;
-using ::testing::ReturnRef;
+using testing::Return;
+using testing::ReturnRef;
 
 using namespace XJ;
 
-class CraftHookProgramVoiceNextMainTest : public ::testing::Test {
+class CraftHookProgramVoiceNextMainTest : public testing::Test {
 protected:
   CraftFactory *craftFactory = nullptr;
   FabricatorFactory *fabricatorFactory = nullptr;

--- a/engine/test/craft/detail_perc_loop/CraftPercLoopContinueTest.cpp
+++ b/engine/test/craft/detail_perc_loop/CraftPercLoopContinueTest.cpp
@@ -92,7 +92,7 @@ protected:
 
    @param excludePercLoopChoiceForSegment3 if desired for the purpose of this test
    */
-  void insertSegments3and4(bool excludePercLoopChoiceForSegment3) {
+  void insertSegments3and4(const bool excludePercLoopChoiceForSegment3) {
     // segment just crafted
     const auto segment3 = store->put(SegmentFixtures::buildSegment(
         chain1,

--- a/engine/test/craft/detail_perc_loop/CraftPercLoopContinueTest.cpp
+++ b/engine/test/craft/detail_perc_loop/CraftPercLoopContinueTest.cpp
@@ -50,7 +50,7 @@ protected:
 
 
     // Chain "Test Print #1" is fabricating segments
-    chain1 = store->put(SegmentFixtures::buildChain(&fake->project1, "Test Print #1", Chain::Type::Production, Chain::State::Fabricate, &fake->template1, ""));
+    chain1 = store->put(SegmentFixtures::buildChain("Test Print #1", Chain::Type::Production, Chain::State::Fabricate, &fake->template1, ""));
     store->put(SegmentFixtures::buildSegment(
         chain1,
         Segment::Type::Initial,

--- a/engine/test/craft/detail_perc_loop/CraftPercLoopContinueTest.cpp
+++ b/engine/test/craft/detail_perc_loop/CraftPercLoopContinueTest.cpp
@@ -18,12 +18,12 @@
 
 // NOLINTNEXTLINE
 using ::testing::_;
-using ::testing::Return;
-using ::testing::ReturnRef;
+using testing::Return;
+using testing::ReturnRef;
 
 using namespace XJ;
 
-class CraftPercLoopContinueTest : public ::testing::Test {
+class CraftPercLoopContinueTest : public testing::Test {
 protected:
   CraftFactory *craftFactory = nullptr;
   FabricatorFactory *fabricatorFactory = nullptr;

--- a/engine/test/craft/detail_perc_loop/CraftPercLoopInitialTest.cpp
+++ b/engine/test/craft/detail_perc_loop/CraftPercLoopInitialTest.cpp
@@ -49,7 +49,6 @@ protected:
     // Chain "Print #2" has 1 initial segment in crafting state - Foundation is complete
     const auto tmpl = ContentFixtures::buildTemplate(&fake->project1, "Test");
     const auto chain2 = store->put(SegmentFixtures::buildChain(
-        &fake->project1,
         "Print #2",
         Chain::Type::Production,
         Chain::State::Fabricate,

--- a/engine/test/craft/detail_perc_loop/CraftPercLoopInitialTest.cpp
+++ b/engine/test/craft/detail_perc_loop/CraftPercLoopInitialTest.cpp
@@ -18,12 +18,12 @@
 
 // NOLINTNEXTLINE
 using ::testing::_;
-using ::testing::Return;
-using ::testing::ReturnRef;
+using testing::Return;
+using testing::ReturnRef;
 
 using namespace XJ;
 
-class CraftPercLoopInitialTest : public ::testing::Test {
+class CraftPercLoopInitialTest : public testing::Test {
 protected:
   CraftFactory *craftFactory = nullptr;
   FabricatorFactory *fabricatorFactory = nullptr;

--- a/engine/test/craft/detail_perc_loop/CraftPercLoopNextMacroTest.cpp
+++ b/engine/test/craft/detail_perc_loop/CraftPercLoopNextMacroTest.cpp
@@ -18,12 +18,12 @@
 
 // NOLINTNEXTLINE
 using ::testing::_;
-using ::testing::Return;
-using ::testing::ReturnRef;
+using testing::Return;
+using testing::ReturnRef;
 
 using namespace XJ;
 
-class CraftPercLoopNextMacroTest : public ::testing::Test {
+class CraftPercLoopNextMacroTest : public testing::Test {
 protected:
   CraftFactory *craftFactory = nullptr;
   FabricatorFactory *fabricatorFactory = nullptr;

--- a/engine/test/craft/detail_perc_loop/CraftPercLoopNextMacroTest.cpp
+++ b/engine/test/craft/detail_perc_loop/CraftPercLoopNextMacroTest.cpp
@@ -49,7 +49,7 @@ protected:
     fake->setupFixtureB3(sourceMaterial);
 
     // Chain "Test Print #1" has 5 total segments
-    chain1 = store->put(SegmentFixtures::buildChain(&fake->project1, "Test Print #1", Chain::Type::Production, Chain::State::Fabricate, &fake->template1, ""));
+    chain1 = store->put(SegmentFixtures::buildChain("Test Print #1", Chain::Type::Production, Chain::State::Fabricate, &fake->template1, ""));
     store->put(SegmentFixtures::buildSegment(
         chain1,
         Segment::Type::Initial,

--- a/engine/test/craft/detail_perc_loop/CraftPercLoopNextMainTest.cpp
+++ b/engine/test/craft/detail_perc_loop/CraftPercLoopNextMainTest.cpp
@@ -18,12 +18,12 @@
 
 // NOLINTNEXTLINE
 using ::testing::_;
-using ::testing::Return;
-using ::testing::ReturnRef;
+using testing::Return;
+using testing::ReturnRef;
 
 using namespace XJ;
 
-class CraftPercLoopNextMainTest : public ::testing::Test {
+class CraftPercLoopNextMainTest : public testing::Test {
 protected:
   CraftFactory *craftFactory = nullptr;
   FabricatorFactory *fabricatorFactory = nullptr;

--- a/engine/test/craft/detail_perc_loop/CraftPercLoopNextMainTest.cpp
+++ b/engine/test/craft/detail_perc_loop/CraftPercLoopNextMainTest.cpp
@@ -49,7 +49,7 @@ protected:
     fake->setupFixtureB3(sourceMaterial);
 
     // Chain "Test Print #1" has 5 total segments
-    chain1 = store->put(SegmentFixtures::buildChain(&fake->project1, "Test Print #1", Chain::Type::Production, Chain::State::Fabricate, &fake->template1, ""));
+    chain1 = store->put(SegmentFixtures::buildChain("Test Print #1", Chain::Type::Production, Chain::State::Fabricate, &fake->template1, ""));
     store->put(SegmentFixtures::buildSegment(
         chain1,
         0,

--- a/engine/test/craft/detail_perc_loop/CraftPercLoopProgramVoiceContinueTest.cpp
+++ b/engine/test/craft/detail_perc_loop/CraftPercLoopProgramVoiceContinueTest.cpp
@@ -51,7 +51,7 @@ protected:
     setupCustomFixtures();
 
     // Chain "Test Print #1" has 5 total segments
-    chain1 = store->put(SegmentFixtures::buildChain(&fake->project1, "Test Print #1", Chain::Type::Production, Chain::State::Fabricate, &fake->template1, ""));
+    chain1 = store->put(SegmentFixtures::buildChain("Test Print #1", Chain::Type::Production, Chain::State::Fabricate, &fake->template1, ""));
     store->put(SegmentFixtures::buildSegment(
         chain1,
         Segment::Type::Initial,

--- a/engine/test/craft/detail_perc_loop/CraftPercLoopProgramVoiceContinueTest.cpp
+++ b/engine/test/craft/detail_perc_loop/CraftPercLoopProgramVoiceContinueTest.cpp
@@ -18,12 +18,12 @@
 
 // NOLINTNEXTLINE
 using ::testing::_;
-using ::testing::Return;
-using ::testing::ReturnRef;
+using testing::Return;
+using testing::ReturnRef;
 
 using namespace XJ;
 
-class CraftPercLoopProgramVoiceContinueTest : public ::testing::Test {
+class CraftPercLoopProgramVoiceContinueTest : public testing::Test {
 protected:
   CraftFactory *craftFactory = nullptr;
   FabricatorFactory *fabricatorFactory = nullptr;

--- a/engine/test/craft/detail_perc_loop/CraftPercLoopProgramVoiceInitialTest.cpp
+++ b/engine/test/craft/detail_perc_loop/CraftPercLoopProgramVoiceInitialTest.cpp
@@ -18,12 +18,12 @@
 
 // NOLINTNEXTLINE
 using ::testing::_;
-using ::testing::Return;
-using ::testing::ReturnRef;
+using testing::Return;
+using testing::ReturnRef;
 
 using namespace XJ;
 
-class CraftPercLoopProgramVoiceInitialTest : public ::testing::Test {
+class CraftPercLoopProgramVoiceInitialTest : public testing::Test {
 protected:
   CraftFactory *craftFactory = nullptr;
   FabricatorFactory * fabricatorFactory = nullptr;

--- a/engine/test/craft/detail_perc_loop/CraftPercLoopProgramVoiceNextMacroTest.cpp
+++ b/engine/test/craft/detail_perc_loop/CraftPercLoopProgramVoiceNextMacroTest.cpp
@@ -107,7 +107,7 @@ protected:
 
    @param excludePercLoopChoiceForSegment3 if desired for the purpose of this test
    */
-  void insertSegments3and4(bool excludePercLoopChoiceForSegment3) {
+  void insertSegments3and4(const bool excludePercLoopChoiceForSegment3) {
     // Chain "Test Print #1" has this segment that was just crafted
     const auto segment3 = store->put(SegmentFixtures::buildSegment(
         chain1,

--- a/engine/test/craft/detail_perc_loop/CraftPercLoopProgramVoiceNextMacroTest.cpp
+++ b/engine/test/craft/detail_perc_loop/CraftPercLoopProgramVoiceNextMacroTest.cpp
@@ -51,7 +51,7 @@ protected:
     setupCustomFixtures();
 
     // Chain "Test Print #1" has 5 total segments
-    chain1 = store->put(SegmentFixtures::buildChain(&fake->project1, "Test Print #1", Chain::Type::Production, Chain::State::Fabricate, &fake->template1, ""));
+    chain1 = store->put(SegmentFixtures::buildChain("Test Print #1", Chain::Type::Production, Chain::State::Fabricate, &fake->template1, ""));
     store->put(SegmentFixtures::buildSegment(
         chain1,
         Segment::Type::Initial,

--- a/engine/test/craft/detail_perc_loop/CraftPercLoopProgramVoiceNextMacroTest.cpp
+++ b/engine/test/craft/detail_perc_loop/CraftPercLoopProgramVoiceNextMacroTest.cpp
@@ -18,12 +18,12 @@
 
 // NOLINTNEXTLINE
 using ::testing::_;
-using ::testing::Return;
-using ::testing::ReturnRef;
+using testing::Return;
+using testing::ReturnRef;
 
 using namespace XJ;
 
-class CraftPercLoopProgramVoiceNextMacroTest : public ::testing::Test {
+class CraftPercLoopProgramVoiceNextMacroTest : public testing::Test {
 protected:
   CraftFactory *craftFactory = nullptr;
   FabricatorFactory *fabricatorFactory = nullptr;

--- a/engine/test/craft/detail_perc_loop/CraftPercLoopProgramVoiceNextMainTest.cpp
+++ b/engine/test/craft/detail_perc_loop/CraftPercLoopProgramVoiceNextMainTest.cpp
@@ -18,12 +18,12 @@
 
 // NOLINTNEXTLINE
 using ::testing::_;
-using ::testing::Return;
-using ::testing::ReturnRef;
+using testing::Return;
+using testing::ReturnRef;
 
 using namespace XJ;
 
-class CraftPercLoopProgramVoiceNextMainTest : public ::testing::Test {
+class CraftPercLoopProgramVoiceNextMainTest : public testing::Test {
 protected:
   CraftFactory *craftFactory = nullptr;
   FabricatorFactory *fabricatorFactory = nullptr;

--- a/engine/test/craft/detail_perc_loop/CraftPercLoopProgramVoiceNextMainTest.cpp
+++ b/engine/test/craft/detail_perc_loop/CraftPercLoopProgramVoiceNextMainTest.cpp
@@ -52,7 +52,6 @@ protected:
 
     // Chain "Test Print #1" has 5 total segments
     chain1 = store->put(SegmentFixtures::buildChain(
-        &fake->project1,
         &fake->template1,
         "Test Print #1",
         Chain::Type::Production,

--- a/engine/test/craft/detail_perc_loop/CraftPercLoop_LayeredVoicesTest.cpp
+++ b/engine/test/craft/detail_perc_loop/CraftPercLoop_LayeredVoicesTest.cpp
@@ -17,15 +17,15 @@
 
 // NOLINTNEXTLINE
 using ::testing::_;
-using ::testing::Return;
-using ::testing::ReturnRef;
+using testing::Return;
+using testing::ReturnRef;
 
 using namespace XJ;
 
 /**
   Percussion-type Loop-mode fabrication composited of layered Patterns https://github.com/xjmusic/xjmusic/issues/267
   */
-class CraftPercLoop_LayeredVoicesTest : public ::testing::Test {
+class CraftPercLoop_LayeredVoicesTest : public testing::Test {
 protected:
   CraftFactory *craftFactory = nullptr;
   FabricatorFactory *fabricatorFactory = nullptr;

--- a/engine/test/craft/detail_perc_loop/CraftPercLoop_LayeredVoicesTest.cpp
+++ b/engine/test/craft/detail_perc_loop/CraftPercLoop_LayeredVoicesTest.cpp
@@ -48,7 +48,7 @@ protected:
     setupCustomFixtures();
 
     // Chain "Test Print #1" has 5 total segments
-    const auto chain1 = store->put(SegmentFixtures::buildChain(&fake->project1, "Test Print #1", Chain::Type::Production, Chain::State::Fabricate, &fake->template1, ""));
+    const auto chain1 = store->put(SegmentFixtures::buildChain("Test Print #1", Chain::Type::Production, Chain::State::Fabricate, &fake->template1, ""));
     store->put(SegmentFixtures::buildSegment(
         chain1,
         Segment::Type::Initial,

--- a/engine/test/craft/macro_main/CraftFoundationContinueTest.cpp
+++ b/engine/test/craft/macro_main/CraftFoundationContinueTest.cpp
@@ -20,12 +20,12 @@
 
 // NOLINTNEXTLINE
 using ::testing::_;
-using ::testing::Return;
-using ::testing::ReturnRef;
+using testing::Return;
+using testing::ReturnRef;
 
 using namespace XJ;
 
-class CraftFoundationContinueTest : public ::testing::Test {
+class CraftFoundationContinueTest : public testing::Test {
 protected:
   CraftFactory *craftFactory = nullptr;
   FabricatorFactory *fabricatorFactory = nullptr;

--- a/engine/test/craft/macro_main/CraftFoundationContinueTest.cpp
+++ b/engine/test/craft/macro_main/CraftFoundationContinueTest.cpp
@@ -49,7 +49,7 @@ protected:
     fake->setupFixtureB2(sourceMaterial);
 
     // Chain "Test Print #1" has 5 total segments
-    const auto chain1 = store->put(SegmentFixtures::buildChain(&fake->project1, "Test Print #1", Chain::Type::Production, Chain::State::Fabricate, &fake->template1, ""));
+    const auto chain1 = store->put(SegmentFixtures::buildChain("Test Print #1", Chain::Type::Production, Chain::State::Fabricate, &fake->template1, ""));
     store->put(SegmentFixtures::buildSegment(
         chain1,
         0,

--- a/engine/test/craft/macro_main/CraftFoundationInitialTest.cpp
+++ b/engine/test/craft/macro_main/CraftFoundationInitialTest.cpp
@@ -18,12 +18,12 @@
 
 // NOLINTNEXTLINE
 using ::testing::_;
-using ::testing::Return;
-using ::testing::ReturnRef;
+using testing::Return;
+using testing::ReturnRef;
 
 using namespace XJ;
 
-class CraftFoundationInitialTest : public ::testing::Test {
+class CraftFoundationInitialTest : public testing::Test {
 protected:
   CraftFactory *craftFactory = nullptr;
   FabricatorFactory *fabricatorFactory = nullptr;

--- a/engine/test/craft/macro_main/CraftFoundationInitialTest.cpp
+++ b/engine/test/craft/macro_main/CraftFoundationInitialTest.cpp
@@ -44,7 +44,6 @@ protected:
 
     // Chain "Print #2" has 1 initial planned segment
     const auto chain2 = store->put(SegmentFixtures::buildChain(
-        &fake->project1,
         &fake->template1,
         "Print #2",
         Chain::Type::Production,

--- a/engine/test/craft/macro_main/CraftFoundationNextMacroTest.cpp
+++ b/engine/test/craft/macro_main/CraftFoundationNextMacroTest.cpp
@@ -18,8 +18,8 @@
 
 // NOLINTNEXTLINE
 using ::testing::_;
-using ::testing::Return;
-using ::testing::ReturnRef;
+using testing::Return;
+using testing::ReturnRef;
 
 using namespace XJ;
 

--- a/engine/test/craft/macro_main/CraftFoundationNextMacroTest.cpp
+++ b/engine/test/craft/macro_main/CraftFoundationNextMacroTest.cpp
@@ -46,7 +46,7 @@ TEST(CraftFoundationNextMacroTest, CraftFoundationNextMacro) {
     fake->setupFixtureB2(sourceMaterial);
 
     // Chain "Test Print #1" has 5 total segments
-    const auto chain1 = store->put(SegmentFixtures::buildChain(&fake->project1, "Test Print #1", Chain::Type::Production, Chain::State::Fabricate, &fake->template1, ""));
+    const auto chain1 = store->put(SegmentFixtures::buildChain("Test Print #1", Chain::Type::Production, Chain::State::Fabricate, &fake->template1, ""));
     store->put(SegmentFixtures::buildSegment(
         chain1,
         0,

--- a/engine/test/craft/macro_main/CraftFoundationNextMainTest.cpp
+++ b/engine/test/craft/macro_main/CraftFoundationNextMainTest.cpp
@@ -19,12 +19,12 @@
 
 // NOLINTNEXTLINE
 using ::testing::_;
-using ::testing::Return;
-using ::testing::ReturnRef;
+using testing::Return;
+using testing::ReturnRef;
 
 using namespace XJ;
 
-class CraftFoundationNextMainTest : public ::testing::Test {
+class CraftFoundationNextMainTest : public testing::Test {
 protected:
   CraftFactory *craftFactory = nullptr;
   FabricatorFactory *fabricatorFactory = nullptr;

--- a/engine/test/craft/macro_main/CraftFoundationNextMainTest.cpp
+++ b/engine/test/craft/macro_main/CraftFoundationNextMainTest.cpp
@@ -49,7 +49,7 @@ protected:
     fake->setupFixtureB2(sourceMaterial);
 
     // Chain "Test Print #1" has 5 total segments
-    chain1 = store->put(SegmentFixtures::buildChain(&fake->project1, "Test Print #1", Chain::Type::Production, Chain::State::Fabricate, &fake->template1, ""));
+    chain1 = store->put(SegmentFixtures::buildChain("Test Print #1", Chain::Type::Production, Chain::State::Fabricate, &fake->template1, ""));
     store->put(SegmentFixtures::buildSegment(
         chain1,
         0,

--- a/engine/test/craft/macro_main/CraftSegmentOutputEncoderTest.cpp
+++ b/engine/test/craft/macro_main/CraftSegmentOutputEncoderTest.cpp
@@ -45,7 +45,6 @@ protected:
 
     // Chain "Print #2" has 1 initial planned segment
     const auto chain2 = store->put(SegmentFixtures::buildChain(
-        &fake->project1,
         "Print #2",
         Chain::Type::Production,
         Chain::State::Fabricate,

--- a/engine/test/craft/macro_main/CraftSegmentOutputEncoderTest.cpp
+++ b/engine/test/craft/macro_main/CraftSegmentOutputEncoderTest.cpp
@@ -17,12 +17,12 @@
 
 // NOLINTNEXTLINE
 using ::testing::_;
-using ::testing::Return;
-using ::testing::ReturnRef;
+using testing::Return;
+using testing::ReturnRef;
 
 using namespace XJ;
 
-class CraftSegmentOutputEncoderTest : public ::testing::Test {
+class CraftSegmentOutputEncoderTest : public testing::Test {
 protected:
   CraftFactory *craftFactory = nullptr;
   FabricatorFactory *fabricatorFactory = nullptr;

--- a/engine/test/craft/macro_main/CraftSegmentPatternMemeTest.cpp
+++ b/engine/test/craft/macro_main/CraftSegmentPatternMemeTest.cpp
@@ -17,8 +17,8 @@
 
 // NOLINTNEXTLINE
 using ::testing::_;
-using ::testing::Return;
-using ::testing::ReturnRef;
+using testing::Return;
+using testing::ReturnRef;
 
 using namespace XJ;
 

--- a/engine/test/craft/macro_main/CraftSegmentPatternMemeTest.cpp
+++ b/engine/test/craft/macro_main/CraftSegmentPatternMemeTest.cpp
@@ -49,7 +49,7 @@ TEST(CraftSegmentPatternMemeTest, CraftSegment) {
     fake->setupFixtureB2(sourceMaterial);
 
     // Chain "Test Print #1" has 5 total segments
-    const auto chain = store->put(SegmentFixtures::buildChain(&fake->project1, "Test Print #1", Chain::Type::Production, Chain::State::Fabricate, &fake->template1, ""));
+    const auto chain = store->put(SegmentFixtures::buildChain("Test Print #1", Chain::Type::Production, Chain::State::Fabricate, &fake->template1, ""));
 
     // Preceding Segment
     const auto previousSegment = store->put(SegmentFixtures::buildSegment(

--- a/engine/test/craft/macro_main/MacroFromOverlappingMemeSequencesTest.cpp
+++ b/engine/test/craft/macro_main/MacroFromOverlappingMemeSequencesTest.cpp
@@ -105,7 +105,7 @@ protected:
     sourceMaterial->put(templateBinding1);
 
     // Chain "Test Print #1" has 5 total segments
-    const auto chain1 = store->put(SegmentFixtures::buildChain(&project1, "Test Print #1", Chain::Type::Production, Chain::State::Fabricate, &template1, ""));
+    const auto chain1 = store->put(SegmentFixtures::buildChain("Test Print #1", Chain::Type::Production, Chain::State::Fabricate, &template1, ""));
     auto segment1 = store->put(SegmentFixtures::buildSegment(
         chain1,
         0,

--- a/engine/test/craft/macro_main/MacroFromOverlappingMemeSequencesTest.cpp
+++ b/engine/test/craft/macro_main/MacroFromOverlappingMemeSequencesTest.cpp
@@ -17,15 +17,15 @@
 
 // NOLINTNEXTLINE
 using ::testing::_;
-using ::testing::Return;
-using ::testing::ReturnRef;
+using testing::Return;
+using testing::ReturnRef;
 
 using namespace XJ;
 
 /**
  Choose next Macro program based on the memes of the last sequence from the previous Macro program https://github.com/xjmusic/xjmusic/issues/299
  */
-class MacroFromOverlappingMemeSequencesTest : public ::testing::Test {
+class MacroFromOverlappingMemeSequencesTest : public testing::Test {
 protected:
   int REPEAT_TIMES = 100;
   MacroMainCraft *subject = nullptr;

--- a/engine/test/craft/transition/CraftTransitionContinueTest.cpp
+++ b/engine/test/craft/transition/CraftTransitionContinueTest.cpp
@@ -91,7 +91,7 @@ protected:
 
    @param excludeTransitionChoiceForSegment3 if desired for the purpose of this test
    */
-  void insertSegments3and4(bool excludeTransitionChoiceForSegment3) {
+  void insertSegments3and4(const bool excludeTransitionChoiceForSegment3) {
     // segment just crafted
     const auto segment3 = store->put(SegmentFixtures::buildSegment(
         chain1,

--- a/engine/test/craft/transition/CraftTransitionContinueTest.cpp
+++ b/engine/test/craft/transition/CraftTransitionContinueTest.cpp
@@ -49,7 +49,7 @@ protected:
     fake->setupFixtureB3(sourceMaterial);
 
     // Chain "Test Print #1" is fabricating segments
-    chain1 = store->put(SegmentFixtures::buildChain(&fake->project1, "Test Print #1", Chain::Type::Production, Chain::State::Fabricate, &fake->template1, ""));
+    chain1 = store->put(SegmentFixtures::buildChain("Test Print #1", Chain::Type::Production, Chain::State::Fabricate, &fake->template1, ""));
     store->put(SegmentFixtures::buildSegment(
         chain1,
         Segment::Type::Initial,

--- a/engine/test/craft/transition/CraftTransitionContinueTest.cpp
+++ b/engine/test/craft/transition/CraftTransitionContinueTest.cpp
@@ -18,12 +18,12 @@
 
 // NOLINTNEXTLINE
 using ::testing::_;
-using ::testing::Return;
-using ::testing::ReturnRef;
+using testing::Return;
+using testing::ReturnRef;
 
 using namespace XJ;
 
-class CraftTransitionContinueTest : public ::testing::Test {
+class CraftTransitionContinueTest : public testing::Test {
 protected:
   CraftFactory *craftFactory = nullptr;
   FabricatorFactory *fabricatorFactory = nullptr;

--- a/engine/test/craft/transition/CraftTransitionInitialTest.cpp
+++ b/engine/test/craft/transition/CraftTransitionInitialTest.cpp
@@ -18,12 +18,12 @@
 
 // NOLINTNEXTLINE
 using ::testing::_;
-using ::testing::Return;
-using ::testing::ReturnRef;
+using testing::Return;
+using testing::ReturnRef;
 
 using namespace XJ;
 
-class CraftTransitionInitialTest : public ::testing::Test {
+class CraftTransitionInitialTest : public testing::Test {
 protected:
   CraftFactory *craftFactory = nullptr;
   FabricatorFactory *fabricatorFactory = nullptr;

--- a/engine/test/craft/transition/CraftTransitionInitialTest.cpp
+++ b/engine/test/craft/transition/CraftTransitionInitialTest.cpp
@@ -49,7 +49,6 @@ protected:
     // Chain "Print #2" has 1 initial segment in crafting state - Foundation is complete
     const auto tmpl = ContentFixtures::buildTemplate(&fake->project1, "Test");
     const auto chain2 = store->put(SegmentFixtures::buildChain(
-        &fake->project1,
         "Print #2",
         Chain::Type::Production,
         Chain::State::Fabricate,

--- a/engine/test/craft/transition/CraftTransitionNextMacroTest.cpp
+++ b/engine/test/craft/transition/CraftTransitionNextMacroTest.cpp
@@ -18,12 +18,12 @@
 
 // NOLINTNEXTLINE
 using ::testing::_;
-using ::testing::Return;
-using ::testing::ReturnRef;
+using testing::Return;
+using testing::ReturnRef;
 
 using namespace XJ;
 
-class CraftTransitionNextMacroTest : public ::testing::Test {
+class CraftTransitionNextMacroTest : public testing::Test {
 protected:
   CraftFactory *craftFactory = nullptr;
   FabricatorFactory *fabricatorFactory = nullptr;

--- a/engine/test/craft/transition/CraftTransitionNextMacroTest.cpp
+++ b/engine/test/craft/transition/CraftTransitionNextMacroTest.cpp
@@ -49,7 +49,7 @@ protected:
     fake->setupFixtureB3(sourceMaterial);
 
     // Chain "Test Print #1" has 5 total segments
-    chain1 = store->put(SegmentFixtures::buildChain(&fake->project1, "Test Print #1", Chain::Type::Production, Chain::State::Fabricate, &fake->template1, ""));
+    chain1 = store->put(SegmentFixtures::buildChain("Test Print #1", Chain::Type::Production, Chain::State::Fabricate, &fake->template1, ""));
     store->put(SegmentFixtures::buildSegment(
         chain1,
         Segment::Type::Initial,

--- a/engine/test/craft/transition/CraftTransitionNextMainTest.cpp
+++ b/engine/test/craft/transition/CraftTransitionNextMainTest.cpp
@@ -18,12 +18,12 @@
 
 // NOLINTNEXTLINE
 using ::testing::_;
-using ::testing::Return;
-using ::testing::ReturnRef;
+using testing::Return;
+using testing::ReturnRef;
 
 using namespace XJ;
 
-class CraftTransitionNextMainTest : public ::testing::Test {
+class CraftTransitionNextMainTest : public testing::Test {
 protected:
   CraftFactory *craftFactory = nullptr;
   FabricatorFactory *fabricatorFactory = nullptr;

--- a/engine/test/craft/transition/CraftTransitionNextMainTest.cpp
+++ b/engine/test/craft/transition/CraftTransitionNextMainTest.cpp
@@ -49,7 +49,7 @@ protected:
     fake->setupFixtureB3(sourceMaterial);
 
     // Chain "Test Print #1" has 5 total segments
-    chain1 = store->put(SegmentFixtures::buildChain(&fake->project1, "Test Print #1", Chain::Type::Production, Chain::State::Fabricate, &fake->template1, ""));
+    chain1 = store->put(SegmentFixtures::buildChain("Test Print #1", Chain::Type::Production, Chain::State::Fabricate, &fake->template1, ""));
     store->put(SegmentFixtures::buildSegment(
         chain1,
         0,

--- a/engine/test/craft/transition/CraftTransitionProgramVoiceContinueTest.cpp
+++ b/engine/test/craft/transition/CraftTransitionProgramVoiceContinueTest.cpp
@@ -51,7 +51,7 @@ protected:
     setupCustomFixtures();
 
     // Chain "Test Print #1" has 5 total segments
-    chain1 = store->put(SegmentFixtures::buildChain(&fake->project1, "Test Print #1", Chain::Type::Production, Chain::State::Fabricate, &fake->template1, ""));
+    chain1 = store->put(SegmentFixtures::buildChain("Test Print #1", Chain::Type::Production, Chain::State::Fabricate, &fake->template1, ""));
     store->put(SegmentFixtures::buildSegment(
         chain1,
         Segment::Type::Initial,

--- a/engine/test/craft/transition/CraftTransitionProgramVoiceContinueTest.cpp
+++ b/engine/test/craft/transition/CraftTransitionProgramVoiceContinueTest.cpp
@@ -18,12 +18,12 @@
 
 // NOLINTNEXTLINE
 using ::testing::_;
-using ::testing::Return;
-using ::testing::ReturnRef;
+using testing::Return;
+using testing::ReturnRef;
 
 using namespace XJ;
 
-class CraftTransitionProgramVoiceContinueTest : public ::testing::Test {
+class CraftTransitionProgramVoiceContinueTest : public testing::Test {
 protected:
   CraftFactory *craftFactory = nullptr;
   FabricatorFactory *fabricatorFactory = nullptr;

--- a/engine/test/craft/transition/CraftTransitionProgramVoiceInitialTest.cpp
+++ b/engine/test/craft/transition/CraftTransitionProgramVoiceInitialTest.cpp
@@ -18,12 +18,12 @@
 
 // NOLINTNEXTLINE
 using ::testing::_;
-using ::testing::Return;
-using ::testing::ReturnRef;
+using testing::Return;
+using testing::ReturnRef;
 
 using namespace XJ;
 
-class CraftTransitionProgramVoiceInitialTest : public ::testing::Test {
+class CraftTransitionProgramVoiceInitialTest : public testing::Test {
 protected:
   CraftFactory *craftFactory = nullptr;
   FabricatorFactory *fabricatorFactory = nullptr;

--- a/engine/test/craft/transition/CraftTransitionProgramVoiceNextMacroTest.cpp
+++ b/engine/test/craft/transition/CraftTransitionProgramVoiceNextMacroTest.cpp
@@ -18,12 +18,12 @@
 
 // NOLINTNEXTLINE
 using ::testing::_;
-using ::testing::Return;
-using ::testing::ReturnRef;
+using testing::Return;
+using testing::ReturnRef;
 
 using namespace XJ;
 
-class CraftTransitionProgramVoiceNextMacroTest : public ::testing::Test {
+class CraftTransitionProgramVoiceNextMacroTest : public testing::Test {
 protected:
   CraftFactory *craftFactory = nullptr;
   FabricatorFactory *fabricatorFactory = nullptr;

--- a/engine/test/craft/transition/CraftTransitionProgramVoiceNextMacroTest.cpp
+++ b/engine/test/craft/transition/CraftTransitionProgramVoiceNextMacroTest.cpp
@@ -108,7 +108,7 @@ protected:
 
    @param excludeTransitionChoiceForSegment3 if desired for the purpose of this test
    */
-  void insertSegments3and4(bool excludeTransitionChoiceForSegment3) {
+  void insertSegments3and4(const bool excludeTransitionChoiceForSegment3) {
     // Chain "Test Print #1" has this segment that was just crafted
     const auto segment3 = store->put(SegmentFixtures::buildSegment(
         chain1,

--- a/engine/test/craft/transition/CraftTransitionProgramVoiceNextMacroTest.cpp
+++ b/engine/test/craft/transition/CraftTransitionProgramVoiceNextMacroTest.cpp
@@ -52,7 +52,7 @@ protected:
 
 
     // Chain "Test Print #1" has 5 total segments
-    chain1 = store->put(SegmentFixtures::buildChain(&fake->project1, "Test Print #1", Chain::Type::Production, Chain::State::Fabricate, &fake->template1, ""));
+    chain1 = store->put(SegmentFixtures::buildChain("Test Print #1", Chain::Type::Production, Chain::State::Fabricate, &fake->template1, ""));
     store->put(SegmentFixtures::buildSegment(
         chain1,
         Segment::Type::Initial,

--- a/engine/test/craft/transition/CraftTransitionProgramVoiceNextMainTest.cpp
+++ b/engine/test/craft/transition/CraftTransitionProgramVoiceNextMainTest.cpp
@@ -53,7 +53,6 @@ protected:
 
     // Chain "Test Print #1" has 5 total segments
     chain1 = store->put(SegmentFixtures::buildChain(
-        &fake->project1,
         &fake->template1,
         "Test Print #1",
         Chain::Type::Production,

--- a/engine/test/craft/transition/CraftTransitionProgramVoiceNextMainTest.cpp
+++ b/engine/test/craft/transition/CraftTransitionProgramVoiceNextMainTest.cpp
@@ -18,12 +18,12 @@
 
 // NOLINTNEXTLINE
 using ::testing::_;
-using ::testing::Return;
-using ::testing::ReturnRef;
+using testing::Return;
+using testing::ReturnRef;
 
 using namespace XJ;
 
-class CraftTransitionProgramVoiceNextMainTest : public ::testing::Test {
+class CraftTransitionProgramVoiceNextMainTest : public testing::Test {
 protected:
   CraftFactory *craftFactory = nullptr;
   FabricatorFactory *fabricatorFactory = nullptr;

--- a/engine/test/craft/transition/CraftTransition_LayeredVoicesTest.cpp
+++ b/engine/test/craft/transition/CraftTransition_LayeredVoicesTest.cpp
@@ -17,15 +17,15 @@
 
 // NOLINTNEXTLINE
 using ::testing::_;
-using ::testing::Return;
-using ::testing::ReturnRef;
+using testing::Return;
+using testing::ReturnRef;
 
 using namespace XJ;
 
 /**
  Transition fabrication composited of layered Patterns https://github.com/xjmusic/xjmusic/issues/267
  */
-class CraftTransition_LayeredVoicesTest : public ::testing::Test {
+class CraftTransition_LayeredVoicesTest : public testing::Test {
 protected:
   CraftFactory *craftFactory = nullptr;
   FabricatorFactory *fabricatorFactory = nullptr;

--- a/engine/test/craft/transition/CraftTransition_LayeredVoicesTest.cpp
+++ b/engine/test/craft/transition/CraftTransition_LayeredVoicesTest.cpp
@@ -48,7 +48,7 @@ protected:
     setupCustomFixtures();
 
     // Chain "Test Print #1" has 5 total segments
-    const auto chain1 = store->put(SegmentFixtures::buildChain(&fake->project1, "Test Print #1", Chain::Type::Production, Chain::State::Fabricate, &fake->template1, ""));
+    const auto chain1 = store->put(SegmentFixtures::buildChain("Test Print #1", Chain::Type::Production, Chain::State::Fabricate, &fake->template1, ""));
     store->put(SegmentFixtures::buildSegment(
         chain1,
         Segment::Type::Initial,

--- a/engine/test/fabricator/FabricatorTest.cpp
+++ b/engine/test/fabricator/FabricatorTest.cpp
@@ -133,7 +133,7 @@ TEST_F(FabricatorTest, GetDistinctChordVoicingTypes) {
   const std::set<Instrument::Type> result = subject->getDistinctChordVoicingTypes();
 
   // Check the result
-  const std::set<Instrument::Type> expected = {Instrument::Type::Bass, Instrument::Type::Sticky, Instrument::Type::Stripe};
+  const std::set expected = {Instrument::Type::Bass, Instrument::Type::Sticky, Instrument::Type::Stripe};
   ASSERT_EQ(expected, result);
 }
 

--- a/engine/test/fabricator/FabricatorTest.cpp
+++ b/engine/test/fabricator/FabricatorTest.cpp
@@ -49,7 +49,6 @@ protected:
 
     // Here's a basic setup that can be replaced for complex tests
     const auto chain = store->put(SegmentFixtures::buildChain(
-        &fake->project1,
         &fake->template1,
         "test",
         Chain::Type::Production,
@@ -80,8 +79,7 @@ protected:
 TEST_F(FabricatorTest, PickReturnedByPicks) {
   sourceMaterial->put(ContentFixtures::buildTemplateBinding(&fake->template1, &fake->library2));
   auto chain = store->put(
-      SegmentFixtures::buildChain(&fake->project1, &fake->template1, "test", Chain::Type::Production,
-                                  Chain::State::Fabricate));
+      SegmentFixtures::buildChain(&fake->template1, "test", Chain::Type::Production, Chain::State::Fabricate));
   store->put(SegmentFixtures::buildSegment(chain, 1, Segment::State::Crafted, "F major", 8, 0.6f, 120.0f, "seg123"));
   segment = store->put(
       SegmentFixtures::buildSegment(chain, 2, Segment::State::Crafting, "G major", 8, 0.6f, 240.0f, "seg123"));
@@ -128,7 +126,7 @@ TEST_F(FabricatorTest, GetDistinctChordVoicingTypes) {
 
   // Create a chain
   store->put(SegmentFixtures::buildChain(
-      &fake->project1, &fake->template1, "test", Chain::Type::Production, Chain::State::Fabricate));
+      &fake->template1, "test", Chain::Type::Production, Chain::State::Fabricate));
 
   // Create a segment choice
   store->put(SegmentFixtures::buildSegmentChoice(
@@ -148,8 +146,7 @@ TEST_F(FabricatorTest, GetDistinctChordVoicingTypes) {
 TEST_F(FabricatorTest, GetType) {
   // Create a chain
   const auto chain = store->put(
-      SegmentFixtures::buildChain(&fake->project1, &fake->template1, "test", Chain::Type::Production,
-                                  Chain::State::Fabricate));
+      SegmentFixtures::buildChain(&fake->template1, "test", Chain::Type::Production, Chain::State::Fabricate));
 
   // Create previous segments with different choices
   const Segment *previousSegment = store->put(
@@ -183,8 +180,7 @@ TEST_F(FabricatorTest, GetType) {
 TEST_F(FabricatorTest, GetMemeIsometryOfNextSequenceInPreviousMacro) {
   // Create a chain
   const auto chain = store->put(
-      SegmentFixtures::buildChain(&fake->project1, &fake->template1, "test", Chain::Type::Production,
-                                  Chain::State::Fabricate));
+      SegmentFixtures::buildChain(&fake->template1, "test", Chain::Type::Production, Chain::State::Fabricate));
 
   // Create previous segments with different choices
   const Segment *previousSegment = store->put(
@@ -216,8 +212,7 @@ TEST_F(FabricatorTest, GetMemeIsometryOfNextSequenceInPreviousMacro) {
 TEST_F(FabricatorTest, GetChordAt) {
   // Create a chain
   const auto chain = store->put(
-      SegmentFixtures::buildChain(&fake->project1, &fake->template1, "test", Chain::Type::Production,
-                                  Chain::State::Fabricate));
+      SegmentFixtures::buildChain(&fake->template1, "test", Chain::Type::Production, Chain::State::Fabricate));
 
   // Create a segment
   segment = store->put(
@@ -243,8 +238,7 @@ TEST_F(FabricatorTest, GetChordAt) {
 TEST_F(FabricatorTest, ComputeProgramRange) {
   // Create a chain
   auto chain = store->put(
-      SegmentFixtures::buildChain(&fake->project1, &fake->template1, "test", Chain::Type::Production,
-                                  Chain::State::Fabricate));
+      SegmentFixtures::buildChain(&fake->template1, "test", Chain::Type::Production, Chain::State::Fabricate));
 
   // Create a segment
   segment = store->put(
@@ -288,8 +282,7 @@ TEST_F(FabricatorTest, ComputeProgramRange) {
 TEST_F(FabricatorTest, ComputeProgramRange_IgnoresAtonalNotes) {
   // Create a chain
   auto chain = store->put(
-      SegmentFixtures::buildChain(&fake->project1, &fake->template1, "test", Chain::Type::Production,
-                                  Chain::State::Fabricate));
+      SegmentFixtures::buildChain(&fake->template1, "test", Chain::Type::Production, Chain::State::Fabricate));
 
   // Create a segment
   segment = store->put(

--- a/engine/test/fabricator/FabricatorTest.cpp
+++ b/engine/test/fabricator/FabricatorTest.cpp
@@ -18,12 +18,12 @@ namespace XJ {
 }
 // NOLINTNEXTLINE
 using ::testing::_;
-using ::testing::Return;
-using ::testing::ReturnRef;
+using testing::Return;
+using testing::ReturnRef;
 
 using namespace XJ;
 
-class FabricatorTest : public ::testing::Test { // NOLINT(*-pro-type-member-init)
+class FabricatorTest : public testing::Test { // NOLINT(*-pro-type-member-init)
 protected:
   int SEQUENCE_TOTAL_BEATS = 64;
   ContentEntityStore *sourceMaterial = nullptr;
@@ -32,9 +32,6 @@ protected:
   Fabricator *subject = nullptr;
   ContentFixtures *fake = nullptr;
   Segment *segment = nullptr;
-
-public:
-
 
 protected:
   void SetUp() override {

--- a/engine/test/fabricator/MarbleBagTest.cpp
+++ b/engine/test/fabricator/MarbleBagTest.cpp
@@ -42,7 +42,7 @@ TEST_F(MarbleBagTest, add_pick) {
   bag.add(1, zebraId, 5);
   spdlog::info("will pick 100 marbles from {}", bag.toString());
   auto result = MarbleBag();
-  auto allowed = std::set<UUID>{frogId, bearId, zebraId};
+  auto allowed = std::set{frogId, bearId, zebraId};
   for (auto i = 0; i < 100; i++) {
     auto pick = bag.pick();
     ASSERT_FALSE(allowed.find(pick) == allowed.end());
@@ -67,7 +67,7 @@ TEST_F(MarbleBagTest, pick_phaseLowerPreferred) {
   bag.add(1, bearId, 30);
   bag.add(2, zebraId, 5);
   spdlog::info("will pick 100 marbles from {}", bag.toString());
-  auto allowed = std::set<UUID>{frogId, bearId};
+  auto allowed = std::set{frogId, bearId};
   for (auto i = 0; i < 100; i++) {
     auto pick = bag.pick();
     ASSERT_FALSE(allowed.find(pick) == allowed.end());
@@ -80,7 +80,7 @@ TEST_F(MarbleBagTest, pick_skipEmptyPhases) {
   bag.add(5, bearId, 30);
   bag.add(6, zebraId, 5);
   spdlog::info("will pick 100 marbles from {}", bag.toString());
-  auto allowed = std::set<UUID>{frogId, bearId};
+  auto allowed = std::set{frogId, bearId};
   for (auto i = 0; i < 100; i++) {
     auto pick = bag.pick();
     ASSERT_FALSE(allowed.find(pick) == allowed.end());

--- a/engine/test/fabricator/MarbleBagTest.cpp
+++ b/engine/test/fabricator/MarbleBagTest.cpp
@@ -12,7 +12,7 @@ using namespace XJ;
  * The Marble Bag: a bag of marbles
  * Because choices should be random https://github.com/xjmusic/xjmusic/issues/291
  */
-class MarbleBagTest : public ::testing::Test {
+class MarbleBagTest : public testing::Test {
 protected:
   UUID frogId = EntityUtils::computeUniqueId();
   UUID bearId = EntityUtils::computeUniqueId();

--- a/engine/test/fabricator/NotePickerTest.cpp
+++ b/engine/test/fabricator/NotePickerTest.cpp
@@ -112,7 +112,7 @@ protected:
 
     std::set<std::string> picked;
     for (auto& note : pickedNotes) {
-      picked.insert(note.toString(Accidental::Sharp));
+      picked.insert(note.toString(Sharp));
     }
 
     if (obj["picks"]) {

--- a/engine/test/fabricator/SegmentRetrospectiveTest.cpp
+++ b/engine/test/fabricator/SegmentRetrospectiveTest.cpp
@@ -36,8 +36,7 @@ protected:
 
     // Chain "Test Print #1" has 5 total segments
     Chain *chain1 = store->put(
-        SegmentFixtures::buildChain(&fake.project1, "Test Print #1", Chain::Type::Production, Chain::State::Fabricate,
-                                    &fake.template1));
+        SegmentFixtures::buildChain("Test Print #1", Chain::Type::Production, Chain::State::Fabricate, &fake.template1));
     segment0 = constructSegmentAndChoices(chain1, Segment::Type::Continue, 10, 4, &fake.program4,
                                                      &fake.program4_sequence1_binding0, &fake.program15,
                                                      &fake.program15_sequence1_binding0);

--- a/engine/test/fabricator/SegmentRetrospectiveTest.cpp
+++ b/engine/test/fabricator/SegmentRetrospectiveTest.cpp
@@ -12,7 +12,7 @@
 
 using namespace XJ;
 
-class SegmentRetrospectiveTest : public ::testing::Test {
+class SegmentRetrospectiveTest : public testing::Test {
 protected:
   int SEQUENCE_TOTAL_BEATS = 64;
   UUID patternId = EntityUtils::computeUniqueId();

--- a/engine/test/fabricator/SegmentUtilsTest.cpp
+++ b/engine/test/fabricator/SegmentUtilsTest.cpp
@@ -26,7 +26,7 @@ protected:
   void SetUp() override {
     project = ContentFixtures::buildProject("Test");
     tmpl = ContentFixtures::buildTemplate(&project, "Test");
-    chain = SegmentFixtures::buildChain(&project, "Test", Chain::Type::Production, Chain::State::Fabricate, &tmpl);
+    chain = SegmentFixtures::buildChain("Test", Chain::Type::Production, Chain::State::Fabricate, &tmpl);
     seg0 = SegmentFixtures::buildSegment(
         &chain,
         Segment::Type::Initial,

--- a/engine/test/fabricator/SegmentUtilsTest.cpp
+++ b/engine/test/fabricator/SegmentUtilsTest.cpp
@@ -140,7 +140,7 @@ TEST_F(SegmentUtilsTest, GetLast) {
 
 // Test for getDubbed
 TEST_F(SegmentUtilsTest, GetDubbed) {
-  const std::vector<Segment *> expected = {&seg0, &seg1, &seg2};
+  const std::vector expected = {&seg0, &seg1, &seg2};
 
   const auto actual = SegmentUtils::getCrafted(segments);
 
@@ -195,6 +195,6 @@ TEST_F(SegmentUtilsTest, IsSameButUpdated) {
 
 // Test for getDurationMinMicros
 TEST_F(SegmentUtilsTest, GetDurationMinMicros) {
-  std::vector<Segment> segments = {seg0, seg1, seg2, seg3};
+  std::vector segments = {seg0, seg1, seg2, seg3};
   ASSERT_EQ(32000000L, SegmentUtils::getDurationMinMicros(segments));
 }

--- a/engine/test/fabricator/SegmentUtilsTest.cpp
+++ b/engine/test/fabricator/SegmentUtilsTest.cpp
@@ -12,7 +12,7 @@
 
 using namespace XJ;
 
-class SegmentUtilsTest : public ::testing::Test {
+class SegmentUtilsTest : public testing::Test {
 protected:
   std::vector<Segment *> segments;
   Project project;

--- a/engine/test/meme/MemeIsometryTest.cpp
+++ b/engine/test/meme/MemeIsometryTest.cpp
@@ -76,7 +76,7 @@ TEST(MemeIsometryTest, DoNotMutate) {
 }
 
 TEST(MemeIsometryTest, Score) {
-  auto subject = MemeIsometry::of(MemeTaxonomy::empty(), {"Smooth", "Catlike"});
+  const auto subject = MemeIsometry::of(MemeTaxonomy::empty(), {"Smooth", "Catlike"});
 
   ASSERT_NEAR(1.0, subject.score({"Smooth"}), 0.1);
   ASSERT_NEAR(1.0, subject.score({"Catlike"}), 0.1);
@@ -84,7 +84,7 @@ TEST(MemeIsometryTest, Score) {
 }
 
 TEST(MemeIsometryTest, ScoreEliminatesDuplicates) {
-  auto subject = MemeIsometry::of(MemeTaxonomy::empty(), {"Smooth", "Smooth", "Catlike"});
+  const auto subject = MemeIsometry::of(MemeTaxonomy::empty(), {"Smooth", "Smooth", "Catlike"});
 
   ASSERT_NEAR(1.0, subject.score({"Smooth"}), 0.1);
   ASSERT_NEAR(1.0, subject.score({"Catlike"}), 0.1);

--- a/engine/test/meme/MemeIsometryTest.cpp
+++ b/engine/test/meme/MemeIsometryTest.cpp
@@ -41,7 +41,7 @@ TEST(MemeIsometryTest, Of_List) {
   auto subject = MemeIsometry::of(MemeTaxonomy::empty(), {"Smooth", "Catlike"});
 
   std::set<std::string> sources = subject.getSources();
-  std::vector<std::string> sourcesVector(sources.begin(), sources.end());
+  std::vector sourcesVector(sources.begin(), sources.end());
   std::sort(sourcesVector.begin(), sourcesVector.end());
 
   const std::vector<std::string> expected = {"CATLIKE", "SMOOTH"};
@@ -58,7 +58,7 @@ TEST(MemeIsometryTest, AddMore) {
   subject.add(meme);
 
   std::set<std::string> sources = subject.getSources();
-  std::vector<std::string> sourcesVector(sources.begin(), sources.end());
+  std::vector sourcesVector(sources.begin(), sources.end());
   std::sort(sourcesVector.begin(), sourcesVector.end());
 
   const std::vector<std::string> expected = {"CATLIKE", "SMOOTH"};
@@ -69,7 +69,7 @@ TEST(MemeIsometryTest, DoNotMutate) {
   auto subject = MemeIsometry::of(MemeTaxonomy::empty(), {"Intensity", "Cool", "Dark"}).getSources();
 
   const std::vector<std::string> expected = {"COOL", "DARK", "INTENSITY"};
-  std::vector<std::string> sourcesVector(subject.begin(), subject.end());
+  std::vector sourcesVector(subject.begin(), subject.end());
   std::sort(sourcesVector.begin(), sourcesVector.end());
 
   ASSERT_EQ(expected, sourcesVector);

--- a/engine/test/meme/MemeTaxonomyTest.cpp
+++ b/engine/test/meme/MemeTaxonomyTest.cpp
@@ -52,10 +52,9 @@ TEST(MemeTaxonomyTest, FromStringToString) {
 TEST(MemeTaxonomyTest, FromSetToList) {
   std::set<MapStringToOneOrManyString> input = {
       {{"name", "CO111LOR"}, {"memes", std::set<std::string>{"RED ", "GR333EEN", "BLUE#@"}}},
-      {{"name", "SIZ$%@E"}, {"memes", std::set<std::string>{"L44A&*(RGE", "MED$IUM", "SMA)(&&LL"}}}
-  };
+      {{"name", "SIZ$%@E"}, {"memes", std::set<std::string>{"L44A&*(RGE", "MED$IUM", "SMA)(&&LL"}}}};
 
-  MemeTaxonomy subject(input);
+  const MemeTaxonomy subject(input);
 
   const std::set<MapStringToOneOrManyString> expected = {
       {{"name", "COLOR"}, {"memes", std::set<std::string>{"RED", "GREEN", "BLUE"}}},

--- a/engine/test/music/ChordTest.cpp
+++ b/engine/test/music/ChordTest.cpp
@@ -163,7 +163,7 @@ TEST(Music_Chord, isAcceptable_eharmonicEquivalent) {
 
 
 TEST(Music_Chord, compareTo) {
-  auto source = std::vector<Chord>{
+  auto source = std::vector{
       Chord::of("Db minor"),
       Chord::of("C major"),
       Chord::of("C"),

--- a/engine/test/music/NoteRangeTest.cpp
+++ b/engine/test/music/NoteRangeTest.cpp
@@ -13,34 +13,34 @@ using namespace XJ;
 TEST(Music_NoteRange, Low) {
   const auto subject = NoteRange::ofStrings(std::vector<std::string>{"C3", "E3", "D4", "E5", "F6"});
 
-  ASSERT_TRUE(Note::of("C3") == (subject.low.value()));
+  ASSERT_TRUE(Note::of("C3") == subject.low.value());
 }
 
 
 TEST(Music_NoteRange, High) {
   const auto subject = NoteRange::ofStrings(std::vector<std::string>{"C3", "E3", "D4", "E5", "F6"});
 
-  ASSERT_TRUE(Note::of("F6") == (subject.high.value()));
+  ASSERT_TRUE(Note::of("F6") == subject.high.value());
 }
 
 
 TEST(Music_NoteRange, RangeFromNotes) {
   const auto subject = NoteRange::from(Note::of("C3"), Note::of("C4"));
 
-  ASSERT_TRUE(Note::of("C3") == (subject.low.value()));
-  ASSERT_TRUE(Note::of("C4") == (subject.high.value()));
+  ASSERT_TRUE(Note::of("C3") == subject.low.value());
+  ASSERT_TRUE(Note::of("C4") == subject.high.value());
 }
 
 
 TEST(Music_NoteRange, RangeOfNotes_isEmpty) {
-  const auto subject = NoteRange::ofNotes(std::set<Note>{Note::of("X")});
+  const auto subject = NoteRange::ofNotes(std::set{Note::of("X")});
 
   ASSERT_TRUE(subject.empty());
 }
 
 
 TEST(Music_NoteRange, RangeOfNotes_FromSet) {
-  const auto subject = NoteRange::ofNotes(std::set<Note>{
+  const auto subject = NoteRange::ofNotes(std::set{
       Note::of("C3"),
       Note::of("E3"),
       Note::of("D4"),
@@ -48,13 +48,13 @@ TEST(Music_NoteRange, RangeOfNotes_FromSet) {
       Note::of("F6")
   });
 
-  ASSERT_TRUE(Note::of("C3") == (subject.low.value()));
-  ASSERT_TRUE(Note::of("F6") == (subject.high.value()));
+  ASSERT_TRUE(Note::of("C3") == subject.low.value());
+  ASSERT_TRUE(Note::of("F6") == subject.high.value());
 }
 
 
 TEST(Music_NoteRange, RangeOfNotes_FromVector) {
-  const auto subject = NoteRange::ofNotes(std::vector<Note>{
+  const auto subject = NoteRange::ofNotes(std::vector{
       Note::of("C3"),
       Note::of("E3"),
       Note::of("D4"),
@@ -62,8 +62,8 @@ TEST(Music_NoteRange, RangeOfNotes_FromVector) {
       Note::of("F6")
   });
 
-  ASSERT_TRUE(Note::of("C3") == (subject.low.value()));
-  ASSERT_TRUE(Note::of("F6") == (subject.high.value()));
+  ASSERT_TRUE(Note::of("C3") == subject.low.value());
+  ASSERT_TRUE(Note::of("F6") == subject.high.value());
 }
 
 
@@ -71,14 +71,14 @@ TEST(Music_NoteRange, RangeFromNotes_LowOptional) {
   const auto subject = NoteRange::from(Note::atonal(), Note::of("C4"));
 
   ASSERT_FALSE(subject.low.has_value());
-  ASSERT_TRUE(Note::of("C4") == (subject.high.value()));
+  ASSERT_TRUE(Note::of("C4") == subject.high.value());
 }
 
 
 TEST(Music_NoteRange, RangeFromNotes_HighOptional) {
   const auto subject = NoteRange::from(Note::of("C4"), Note::atonal());
 
-  ASSERT_TRUE(Note::of("C4") == (subject.low.value()));
+  ASSERT_TRUE(Note::of("C4") == subject.low.value());
   ASSERT_FALSE(subject.high.has_value());
 }
 
@@ -86,8 +86,8 @@ TEST(Music_NoteRange, RangeFromNotes_HighOptional) {
 TEST(Music_NoteRange, RangeFromStrings) {
   const auto subject = NoteRange::from("C3", "C4");
 
-  ASSERT_TRUE(Note::of("C3") == (subject.low.value()));
-  ASSERT_TRUE(Note::of("C4") == (subject.high.value()));
+  ASSERT_TRUE(Note::of("C3") == subject.low.value());
+  ASSERT_TRUE(Note::of("C4") == subject.high.value());
 }
 
 
@@ -95,14 +95,14 @@ TEST(Music_NoteRange, RangeFromStrings_LowOptional) {
   const auto subject = NoteRange::from("X", "C4");
 
   ASSERT_FALSE(subject.low.has_value());
-  ASSERT_TRUE(Note::of("C4") == (subject.high.value()));
+  ASSERT_TRUE(Note::of("C4") == subject.high.value());
 }
 
 
 TEST(Music_NoteRange, RangeFromStrings_HighOptional) {
   const auto subject = NoteRange::from("C4", "X");
 
-  ASSERT_TRUE(Note::of("C4") == (subject.low.value()));
+  ASSERT_TRUE(Note::of("C4") == subject.low.value());
   ASSERT_FALSE(subject.high.has_value());
 }
 
@@ -111,8 +111,8 @@ TEST(Music_NoteRange, CopyOf) {
   const auto subject = NoteRange::ofStrings(std::vector<std::string>{"C3", "E3", "D4", "E5", "F6"});
   const auto cp = NoteRange::copyOf(subject);
 
-  ASSERT_TRUE(Note::of("C3") == (cp.low.value()));
-  ASSERT_TRUE(Note::of("F6") == (cp.high.value()));
+  ASSERT_TRUE(Note::of("C3") == cp.low.value());
+  ASSERT_TRUE(Note::of("F6") == cp.high.value());
 }
 
 
@@ -128,21 +128,21 @@ TEST(Music_NoteRange, Expand) {
 
   subject.expand(Note::of("G2"));
 
-  ASSERT_TRUE(Note::of("G2") == (subject.low.value()));
-  ASSERT_TRUE(Note::of("F6") == (subject.high.value()));
+  ASSERT_TRUE(Note::of("G2") == subject.low.value());
+  ASSERT_TRUE(Note::of("F6") == subject.high.value());
 }
 
 
 TEST(Music_NoteRange, Expand_ByNotes) {
   auto subject = NoteRange::ofStrings(std::vector<std::string>{"C3", "E3", "D4", "E5", "F6"});
 
-  subject.expand(std::vector<Note>{
+  subject.expand(std::vector{
       Note::of("G2"),
       Note::of("G6")
   });
 
-  ASSERT_TRUE(Note::of("G2") == (subject.low.value()));
-  ASSERT_TRUE(Note::of("G6") == (subject.high.value()));
+  ASSERT_TRUE(Note::of("G2") == subject.low.value());
+  ASSERT_TRUE(Note::of("G6") == subject.high.value());
 }
 
 
@@ -152,8 +152,8 @@ TEST(Music_NoteRange, Expand_ByRange) {
 
   subject.expand(&expansion);
 
-  ASSERT_TRUE(Note::of("G2") == (subject.low.value()));
-  ASSERT_TRUE(Note::of("G6") == (subject.high.value()));
+  ASSERT_TRUE(Note::of("G2") == subject.low.value());
+  ASSERT_TRUE(Note::of("G6") == subject.high.value());
 }
 
 

--- a/engine/test/music/NoteRangeTest.cpp
+++ b/engine/test/music/NoteRangeTest.cpp
@@ -188,9 +188,9 @@ TEST(Music_NoteRange, DeltaSemitones) {
 
 
 TEST(Music_NoteRange, NoteNearestMedian) {
-  TestHelpers::assertNote("C5", NoteRange::from("C3", "G6").getNoteNearestMedian(PitchClass::C).value());
-  TestHelpers::assertNote("C5", NoteRange::from("C3", "G7").getNoteNearestMedian(PitchClass::C).value());
-  TestHelpers::assertNote("C4", NoteRange::from("C2", "G6").getNoteNearestMedian(PitchClass::C).value());
+  TestHelpers::assertNote("C5", NoteRange::from("C3", "G6").getNoteNearestMedian(C).value());
+  TestHelpers::assertNote("C5", NoteRange::from("C3", "G7").getNoteNearestMedian(C).value());
+  TestHelpers::assertNote("C4", NoteRange::from("C2", "G6").getNoteNearestMedian(C).value());
   ASSERT_FALSE(NoteRange::from("C3", "G6").getNoteNearestMedian(PitchClass::Atonal).has_value());
 }
 

--- a/engine/test/music/NoteTest.cpp
+++ b/engine/test/music/NoteTest.cpp
@@ -89,7 +89,7 @@ TEST(Music_Note, OfPitchClassTest) {
 }
 
 TEST(Music_Note, compareTo) {
-  auto notes = std::vector<Note>{
+  auto notes = std::vector{
       Note::of("C1"),
       Note::of("F#1"),
       Note::of("E1"),

--- a/engine/test/music/NoteTest.cpp
+++ b/engine/test/music/NoteTest.cpp
@@ -83,7 +83,7 @@ TEST(Music_Note, NamedTest) {
 }
 
 TEST(Music_Note, OfPitchClassTest) {
-  const Note note = Note::of(PitchClass::C, 5);
+  const Note note = Note::of(C, 5);
   ASSERT_EQ(5, note.octave);
   ASSERT_EQ(PitchClass::C, note.pitchClass);
 }
@@ -107,7 +107,7 @@ TEST(Music_Note, compareTo) {
   std::sort(notes.begin(), notes.end());
   std::vector<std::string> noteStrings;
   std::transform(notes.begin(), notes.end(), std::back_inserter(noteStrings), [](const Note note) {
-    return note.toString(Accidental::Sharp);
+    return note.toString(Sharp);
   });
 
   ASSERT_EQ( "C1,D1,D#1,E1,F#1,C2,D2,D#2,E2,F#2,C3,D3,D#3,E3", StringUtils::join(noteStrings, ","));
@@ -185,10 +185,10 @@ TEST(Music_Note, median) {
 
 TEST(Music_Note, nextUp) {
   ASSERT_EQ(PitchClass::Atonal, Note::of("X").nextUp(PitchClass::C).pitchClass);
-  TestHelpers::assertNote("C4", Note::of("B3").nextUp(PitchClass::C));
+  TestHelpers::assertNote("C4", Note::of("B3").nextUp(C));
 }
 
 TEST(Music_Note, nextDown) {
   ASSERT_EQ(PitchClass::Atonal, Note::of("X").nextDown(PitchClass::C).pitchClass);
-  TestHelpers::assertNote("C4", Note::of("D4").nextDown(PitchClass::C));
+  TestHelpers::assertNote("C4", Note::of("D4").nextDown(C));
 }

--- a/engine/test/music/PitchClassTest.cpp
+++ b/engine/test/music/PitchClassTest.cpp
@@ -19,32 +19,32 @@ void assertPitchClassOf(
 }
 
 TEST(Music_PitchClass, PitchClassOf) {
-  assertPitchClassOf("C", PitchClass::C, "C", "C");
-  assertPitchClassOf("C#", PitchClass::Cs, "C#", "Db");
-  assertPitchClassOf("Cb", PitchClass::B, "B", "B");
-  assertPitchClassOf("D", PitchClass::D, "D", "D");
-  assertPitchClassOf("D#", PitchClass::Ds, "D#", "Eb");
-  assertPitchClassOf("D♭", PitchClass::Cs, "C#", "Db");
-  assertPitchClassOf("E", PitchClass::E, "E", "E");
-  assertPitchClassOf("E#", PitchClass::F, "F", "F");
-  assertPitchClassOf("E♭", PitchClass::Ds, "D#", "Eb");
-  assertPitchClassOf("F", PitchClass::F, "F", "F");
-  assertPitchClassOf("F#", PitchClass::Fs, "F#", "Gb");
-  assertPitchClassOf("F♭", PitchClass::E, "E", "E");
-  assertPitchClassOf("G", PitchClass::G, "G", "G");
-  assertPitchClassOf("G♯", PitchClass::Gs, "G#", "Ab");
-  assertPitchClassOf("Gb", PitchClass::Fs, "F#", "Gb");
-  assertPitchClassOf("A", PitchClass::A, "A", "A");
-  assertPitchClassOf("A#", PitchClass::As, "A#", "Bb");
-  assertPitchClassOf("Ab", PitchClass::Gs, "G#", "Ab");
-  assertPitchClassOf("B", PitchClass::B, "B", "B");
-  assertPitchClassOf("B#", PitchClass::C, "C", "C");
-  assertPitchClassOf("E♭", PitchClass::Ds, "D#", "Eb");
-  assertPitchClassOf("Bb", PitchClass::As, "A#", "Bb");
-  assertPitchClassOf("z", PitchClass::Atonal, "X", "X");
-  assertPitchClassOf("zzzz", PitchClass::Atonal, "X", "X");
-  assertPitchClassOf("C minor", PitchClass::C, "C", "C");
-  assertPitchClassOf("C#5", PitchClass::Cs, "C#", "Db");
+  assertPitchClassOf("C", C, "C", "C");
+  assertPitchClassOf("C#", Cs, "C#", "Db");
+  assertPitchClassOf("Cb", B, "B", "B");
+  assertPitchClassOf("D", D, "D", "D");
+  assertPitchClassOf("D#", Ds, "D#", "Eb");
+  assertPitchClassOf("D♭", Cs, "C#", "Db");
+  assertPitchClassOf("E", E, "E", "E");
+  assertPitchClassOf("E#", F, "F", "F");
+  assertPitchClassOf("E♭", Ds, "D#", "Eb");
+  assertPitchClassOf("F", F, "F", "F");
+  assertPitchClassOf("F#", Fs, "F#", "Gb");
+  assertPitchClassOf("F♭", E, "E", "E");
+  assertPitchClassOf("G", G, "G", "G");
+  assertPitchClassOf("G♯", Gs, "G#", "Ab");
+  assertPitchClassOf("Gb", Fs, "F#", "Gb");
+  assertPitchClassOf("A", A, "A", "A");
+  assertPitchClassOf("A#", As, "A#", "Bb");
+  assertPitchClassOf("Ab", Gs, "G#", "Ab");
+  assertPitchClassOf("B", B, "B", "B");
+  assertPitchClassOf("B#", C, "C", "C");
+  assertPitchClassOf("E♭", Ds, "D#", "Eb");
+  assertPitchClassOf("Bb", As, "A#", "Bb");
+  assertPitchClassOf("z", Atonal, "X", "X");
+  assertPitchClassOf("zzzz", Atonal, "X", "X");
+  assertPitchClassOf("C minor", C, "C", "C");
+  assertPitchClassOf("C#5", Cs, "C#", "Db");
 }
 
 TEST(Music_PitchClass, StringOf) {

--- a/engine/test/music/RootTest.cpp
+++ b/engine/test/music/RootTest.cpp
@@ -23,19 +23,19 @@ static void assertRoot(const std::string& text, const PitchClass expectPitchClas
 }
 
 TEST(Music_Root, RootOfTest) {
-  assertRoot("C", PitchClass::C, "");
-  assertRoot("Cmaj", PitchClass::C, "maj");
-  assertRoot("B♭min", PitchClass::As, "min");
-  assertRoot("C#dim", PitchClass::Cs, "dim");
-  assertRoot("JAMS", PitchClass::Atonal, "JAMS");
-  assertRoot("CM6add9", PitchClass::C, "M6add9");
-  assertRoot("C dom7b9/13", PitchClass::C, "dom7b9/13");
-  assertRoot("C+∆", PitchClass::C, "+∆");
-  assertRoot("C Ø11", PitchClass::C, "Ø11");
-  assertRoot("C+M7", PitchClass::C, "+M7");
-  assertRoot("C+∆", PitchClass::C, "+∆");
-  assertRoot("C∆#5", PitchClass::C, "∆#5");
-  assertRoot("C+♮7", PitchClass::C, "+♮7");
-  assertRoot("C°", PitchClass::C, "°");
+  assertRoot("C", C, "");
+  assertRoot("Cmaj", C, "maj");
+  assertRoot("B♭min", As, "min");
+  assertRoot("C#dim", Cs, "dim");
+  assertRoot("JAMS", Atonal, "JAMS");
+  assertRoot("CM6add9", C, "M6add9");
+  assertRoot("C dom7b9/13", C, "dom7b9/13");
+  assertRoot("C+∆", C, "+∆");
+  assertRoot("C Ø11", C, "Ø11");
+  assertRoot("C+M7", C, "+M7");
+  assertRoot("C+∆", C, "+∆");
+  assertRoot("C∆#5", C, "∆#5");
+  assertRoot("C+♮7", C, "+♮7");
+  assertRoot("C°", C, "°");
 }
 

--- a/engine/test/music/StepTest.cpp
+++ b/engine/test/music/StepTest.cpp
@@ -7,7 +7,7 @@
 using namespace XJ;
 
 TEST(Music_Step, To) {
-  const Step step = Step::to(PitchClass::B, -1);
+  const Step step = Step::to(B, -1);
 
   ASSERT_EQ(-1, step.deltaOctave);
   ASSERT_EQ(PitchClass::B, step.pitchClass);

--- a/engine/test/segment/SegmentEntityStoreTest.cpp
+++ b/engine/test/segment/SegmentEntityStoreTest.cpp
@@ -32,7 +32,6 @@ protected:
     const Project fakeProject = ContentFixtures::buildProject("fake");
     const auto tmpl = ContentFixtures::buildTemplate(&fakeProject, "Test");
     fakeChain = SegmentFixtures::buildChain(
-        &fakeProject,
         "Print #2",
         Chain::Type::Production,
         Chain::State::Fabricate,
@@ -42,7 +41,6 @@ protected:
     template1 = ContentFixtures::buildTemplate(&project1, "Test Template 1", "test1");
 
     chain3 = subject->put(SegmentFixtures::buildChain(
-        &project1,
         &template1,
         "Test Print #1",
         Chain::Type::Production,
@@ -209,7 +207,6 @@ TEST_F(SegmentEntityStoreTest, CreateAll_ReadAll) {
   auto project1 = ContentFixtures::buildProject("fish");
   auto tmpl = ContentFixtures::buildTemplate(&project1, "fishy");
   auto chain3 = subject->put(SegmentFixtures::buildChain(
-      &project1,
       "Test Print #3",
       Chain::Type::Production,
       Chain::State::Fabricate,
@@ -350,8 +347,8 @@ TEST_F(SegmentEntityStoreTest, ReadAllSegments) {
  */
 TEST_F(SegmentEntityStoreTest, ReadAll_hasNoLimit) {
   const Chain *chain5 = subject->put(
-      SegmentFixtures::buildChain(&project1, "Test Print #1", Chain::Type::Production, Chain::State::Fabricate,
-                                  &template1, "barnacles"));
+      SegmentFixtures::buildChain("Test Print #1", Chain::Type::Production, Chain::State::Fabricate, &template1,
+                                  "barnacles"));
   for (int i = 0; i < 20; i++)
     subject->put(SegmentFixtures::buildSegment(
         chain5,

--- a/engine/test/segment/SegmentEntityStoreTest.cpp
+++ b/engine/test/segment/SegmentEntityStoreTest.cpp
@@ -12,7 +12,7 @@
 
 using namespace XJ;
 
-class SegmentEntityStoreTest : public ::testing::Test {
+class SegmentEntityStoreTest : public testing::Test {
 protected:
   SegmentEntityStore *subject = nullptr;
   Chain fakeChain;
@@ -140,8 +140,8 @@ TEST_F(SegmentEntityStoreTest, Create) {
   EXPECT_EQ(chain3->id, result->chainId);
   EXPECT_EQ(5, result->id);
   EXPECT_EQ(Segment::State::Planned, result->state);
-  EXPECT_EQ(5 * 32 * ValueUtils::MICROS_PER_SECOND, static_cast<long>(result->beginAtChainMicros));
-  EXPECT_EQ(32 * ValueUtils::MICROS_PER_SECOND, static_cast<long>(result->durationMicros.value()));
+  EXPECT_EQ(5 * 32 * ValueUtils::MICROS_PER_SECOND, result->beginAtChainMicros);
+  EXPECT_EQ(32 * ValueUtils::MICROS_PER_SECOND, result->durationMicros.value());
   EXPECT_EQ(64, result->total);
   EXPECT_NEAR(0.74, result->intensity, 0.01);
   EXPECT_EQ("C# minor 7 b9", result->key);
@@ -174,8 +174,8 @@ TEST_F(SegmentEntityStoreTest, Create_Get_Segment) {
   ASSERT_EQ(0, result->id);
   ASSERT_EQ(Segment::Type::NextMacro, result->type);
   ASSERT_EQ(Segment::State::Crafted, result->state);
-  ASSERT_EQ(0, static_cast<long>(result->beginAtChainMicros));
-  ASSERT_EQ(32 * ValueUtils::MICROS_PER_SECOND, static_cast<long>(result->durationMicros.value()));
+  ASSERT_EQ(0, result->beginAtChainMicros);
+  ASSERT_EQ(32 * ValueUtils::MICROS_PER_SECOND, result->durationMicros.value());
   ASSERT_EQ("D Major", result->key);
   ASSERT_EQ(64, result->total);
   ASSERT_NEAR(0.73f, result->intensity, 0.01);
@@ -250,9 +250,9 @@ TEST_F(SegmentEntityStoreTest, ReadSegment) {
   ASSERT_EQ(chain3->id, result->chainId);
   ASSERT_EQ(1, result->id);
   ASSERT_EQ(Segment::State::Crafting, result->state);
-  ASSERT_EQ(32 * ValueUtils::MICROS_PER_SECOND, (long) result->beginAtChainMicros);
+  ASSERT_EQ(32 * ValueUtils::MICROS_PER_SECOND, result->beginAtChainMicros);
   ASSERT_TRUE(result->durationMicros.has_value());
-  ASSERT_EQ(32 * ValueUtils::MICROS_PER_SECOND, (long) result->durationMicros.value());
+  ASSERT_EQ(32 * ValueUtils::MICROS_PER_SECOND, result->durationMicros.value());
   ASSERT_EQ(64, result->total);
   ASSERT_NEAR(0.85f, result->intensity, 0.01);
   ASSERT_EQ("Db minor", result->key);
@@ -392,9 +392,9 @@ TEST_F(SegmentEntityStoreTest, UpdateSegment) {
   ASSERT_EQ(chain3->id, result->chainId);
   ASSERT_EQ(Segment::State::Crafted, result->state);
   ASSERT_NEAR(0.0123, result->waveformPreroll, 0.001);
-  ASSERT_EQ(4 * 32 * ValueUtils::MICROS_PER_SECOND, (long) result->beginAtChainMicros);
+  ASSERT_EQ(4 * 32 * ValueUtils::MICROS_PER_SECOND, result->beginAtChainMicros);
   ASSERT_TRUE(result->durationMicros.has_value());
-  ASSERT_EQ(32 * ValueUtils::MICROS_PER_SECOND, (long) result->durationMicros.value());
+  ASSERT_EQ(32 * ValueUtils::MICROS_PER_SECOND, result->durationMicros.value());
 }
 
 /**

--- a/engine/test/util/ConfigParserTest.cpp
+++ b/engine/test/util/ConfigParserTest.cpp
@@ -37,7 +37,7 @@ TEST(HoconLiteTest, ParseConfig) {
             stringValue = Apples
     )";
 
-  ConfigParser subject = ConfigParser(input);
+  auto subject = ConfigParser(input);
 
   // single values
   ASSERT_EQ("Apples", subject.getSingleValue("stringValue").getString());
@@ -100,7 +100,7 @@ TEST(HoconLiteTest, ParseConfigWithDefaults) {
             intValue = 12
     )";
 
-  ConfigParser subject = ConfigParser(input, ConfigParser(defaults));
+  auto subject = ConfigParser(input, ConfigParser(defaults));
 
   // single values
   ASSERT_EQ("Apples", subject.getSingleValue("stringValue").getString());

--- a/engine/test/util/StringUtilsTest.cpp
+++ b/engine/test/util/StringUtilsTest.cpp
@@ -9,7 +9,7 @@ using namespace XJ;
 
 TEST(StringUtilsTest, Split) {
   const std::string s = "\n  one,     two,\nthree";
-  const char delimiter = ',';
+  constexpr char delimiter = ',';
   const std::vector<std::string> result = StringUtils::split(s, delimiter);
 
   ASSERT_EQ(3, result.size());

--- a/engine/test/util/ValueUtilsTest.cpp
+++ b/engine/test/util/ValueUtilsTest.cpp
@@ -7,14 +7,14 @@
 using namespace XJ;
 
 
-void ASSERT_ARRAY_EQ(std::vector<int> vector1, std::vector<int> vector2) {
+void ASSERT_ARRAY_EQ(const std::vector<int> &vector1, const std::vector<int> &vector2) {
   ASSERT_EQ(vector1.size(), vector2.size());
   for (int i = 0; i < vector1.size(); i++) {
     ASSERT_EQ(vector1[i], vector2[i]);
   }
 }
 
-void ASSERT_ARRAY_EQ(std::vector<std::string> vector1, std::vector<std::string> vector2) {
+void ASSERT_ARRAY_EQ(const std::vector<std::string> &vector1, const std::vector<std::string> &vector2) {
   ASSERT_EQ(vector1.size(), vector2.size());
   for (int i = 0; i < vector1.size(); i++) {
     ASSERT_EQ(vector1[i], vector2[i]);

--- a/engine/test/util/ValueUtilsTest.cpp
+++ b/engine/test/util/ValueUtilsTest.cpp
@@ -112,9 +112,9 @@ TEST(ValueUtils, gcd) {
 }
 
 TEST(ValueUtils, factors) {
-  ASSERT_ARRAY_EQ(std::vector<int>{2, 3, 4}, ValueUtils::factors(12, std::vector<int>{2, 3, 4, 5, 7}));
-  ASSERT_ARRAY_EQ(std::vector<int>{2, 3, 4, 5}, ValueUtils::factors(60, std::vector<int>{2, 3, 4, 5, 7}));
-  ASSERT_ARRAY_EQ(std::vector<int>{2, 3, 5, 7}, ValueUtils::factors(210, std::vector<int>{2, 3, 4, 5, 7}));
+  ASSERT_ARRAY_EQ(std::vector{2, 3, 4}, ValueUtils::factors(12, std::vector{2, 3, 4, 5, 7}));
+  ASSERT_ARRAY_EQ(std::vector{2, 3, 4, 5}, ValueUtils::factors(60, std::vector{2, 3, 4, 5, 7}));
+  ASSERT_ARRAY_EQ(std::vector{2, 3, 5, 7}, ValueUtils::factors(210, std::vector{2, 3, 4, 5, 7}));
 }
 
 TEST(ValueUtils, div) {


### PR DESCRIPTION
- Make some functions const [skip ci]
- Make some functions const
- Use static cast
- Declaration and assignment can be joined
- Local variable can be const
- Member function can be made const
- Member function static where possible
- Parameters const where possible
- Use structured bindings for readability
- Remove unused parameters
- Parameter names should match
- Remove redundant else, cast, and qualifier
- Remove redundant parentheses, template types
