### PR TITLE
Engine refactor ActiveAudio

### DIFF
--- a/engine/include/xjmusic/audio/ActiveAudio.h
+++ b/engine/include/xjmusic/audio/ActiveAudio.h
@@ -14,8 +14,8 @@ namespace XJ {
     const Instrument *instrument;
     const InstrumentAudio *audio;
     InstrumentConfig instrumentConfig;
-    unsigned long long startAtMixerMicros;
-    std::optional<unsigned long long> stopAtMixerMicros;
+    unsigned long long startAtChainMicros;
+    std::optional<unsigned long long> stopAtChainMicros;
     float fromAmplitude;
     float toAmplitude;
 
@@ -24,8 +24,8 @@ namespace XJ {
         const SegmentChoiceArrangementPick *pick,
         const Instrument *instrument,
         const InstrumentAudio *audio,
-        unsigned long long startAtMixerMicros,
-        std::optional<unsigned long long> stopAtMixerMicros,
+        unsigned long long startAtChainMicros,
+        std::optional<unsigned long long> stopAtChainMicros,
         float fromIntensityAmplitude,
         float toIntensityAmplitude);
 
@@ -35,9 +35,9 @@ namespace XJ {
 
     const Instrument * getInstrument();
 
-    unsigned long long getStartAtMixerMicros() const;
+    unsigned long long getStartAtChainMicros() const;
 
-    std::optional<unsigned long long> getStopAtMixerMicros() const;
+    std::optional<unsigned long long> getStopAtChainMicros() const;
 
     const InstrumentAudio * getAudio();
 
@@ -58,7 +58,7 @@ namespace XJ {
      * @return   true if lhs < rhs
      */
     friend bool operator<(const ActiveAudio &lhs, const ActiveAudio &rhs) {
-      return lhs.getStartAtMixerMicros() < rhs.getStartAtMixerMicros();
+      return lhs.getStartAtChainMicros() < rhs.getStartAtChainMicros();
     }
 
   };

--- a/engine/include/xjmusic/craft/Craft.h
+++ b/engine/include/xjmusic/craft/Craft.h
@@ -85,7 +85,7 @@ namespace XJ {
      */
     class Section {
     public:
-      SegmentChord *chord;
+      const SegmentChord *chord;
       float fromPos{};
       float toPos{};
     };

--- a/engine/include/xjmusic/craft/MacroMainCraft.h
+++ b/engine/include/xjmusic/craft/MacroMainCraft.h
@@ -70,7 +70,7 @@ namespace XJ {
      @param mainSequence  of which to compute segment tempo
      @return intensity
      */
-    double computeSegmentIntensity(
+    float computeSegmentIntensity(
         int delta,
         std::optional<const ProgramSequence *> macroSequence,
         std::optional<const ProgramSequence *> mainSequence) const;

--- a/engine/include/xjmusic/fabricator/ChainUtils.h
+++ b/engine/include/xjmusic/fabricator/ChainUtils.h
@@ -25,7 +25,7 @@ namespace XJ {
 
     static std::string getShipKey(const std::string &chainKey, const std::string &extension);
 
-    static long computeFabricatedToChainMicros(const std::vector<Segment *> &segments);
+    static long computeFabricatedToChainMicros(const std::vector<const Segment *> &segments);
 
     static Chain fromTemplate(const Template *tmpl);
 

--- a/engine/include/xjmusic/fabricator/Fabricator.h
+++ b/engine/include/xjmusic/fabricator/Fabricator.h
@@ -113,7 +113,7 @@ namespace XJ {
 
      @return arrangements for segment
      */
-    virtual std::set<SegmentChoiceArrangement *> getArrangements();
+    virtual std::set<const SegmentChoiceArrangement *> getArrangements();
 
     /**
      Get segment arrangements for a given choice
@@ -121,7 +121,7 @@ namespace XJ {
      @param choices to get segment arrangements for
      @return segments arrangements for the given segment choice
      */
-    virtual std::set<SegmentChoiceArrangement *> getArrangements(std::set<const SegmentChoice *> &choices);
+    virtual std::set<const SegmentChoiceArrangement *> getArrangements(std::set<const SegmentChoice *> &choices);
 
     /**
      Get the Chain
@@ -143,7 +143,7 @@ namespace XJ {
 
      @return choices for segment
      */
-    [[nodiscard]] virtual std::set<SegmentChoice *> getChoices() const;
+    [[nodiscard]] virtual std::set<const SegmentChoice *> getChoices() const;
 
     /**
      Determine if a choice has been previously crafted
@@ -161,7 +161,7 @@ namespace XJ {
 
      @return choice if previously made, or null if none is found
      */
-    virtual std::set<SegmentChoice *> getChoicesIfContinued(const Program::Type programType);
+    virtual std::set<const SegmentChoice *> getChoicesIfContinued(const Program::Type programType);
 
     /**
      Determine if a choice has been previously crafted
@@ -169,7 +169,7 @@ namespace XJ {
 
      @return choice if previously made, or null if none is found
      */
-    virtual std::optional<SegmentChoice *> getChoiceIfContinued(Instrument::Type instrumentType);
+    virtual std::optional<const SegmentChoice *> getChoiceIfContinued(Instrument::Type instrumentType);
 
     /**
      Determine if a choice has been previously crafted
@@ -177,7 +177,7 @@ namespace XJ {
 
      @return choice if previously made, or null if none is found
      */
-    virtual std::optional<SegmentChoice *>
+    virtual std::optional<const SegmentChoice *>
     getChoiceIfContinued(Instrument::Type instrumentType, Instrument::Mode instrumentMode);
 
     /**
@@ -187,7 +187,7 @@ namespace XJ {
      @param position in segment
      @return ChordEntity
      */
-    virtual std::optional<SegmentChord *> getChordAt(float position);
+    virtual std::optional<const SegmentChord *> getChordAt(float position);
 
     /**
      fetch the main-type choice for the current segment in the chain
@@ -253,14 +253,14 @@ namespace XJ {
 
      @return macro-type segment choice, null if none found
      */
-    virtual std::optional<SegmentChoice *> getMacroChoiceOfPreviousSegment();
+    virtual std::optional<const SegmentChoice *> getMacroChoiceOfPreviousSegment();
 
     /**
      fetch the main-type choice for the previous segment in the chain
 
      @return main-type segment choice, null if none found
      */
-    virtual std::optional<SegmentChoice *> getPreviousMainChoice();
+    virtual std::optional<const SegmentChoice *> getPreviousMainChoice();
 
     /**
      Get the configuration of the current main program
@@ -315,7 +315,7 @@ namespace XJ {
 
      @return arrangement picks for segment
      */
-    virtual std::set<SegmentChoiceArrangementPick *> getPicks();
+    virtual std::set<const SegmentChoiceArrangementPick *> getPicks();
 
     /**
      Get the picks for a given choice, in order of position ascending from beginning of segment
@@ -323,7 +323,7 @@ namespace XJ {
      @param choice for which to get picks
      @return picks
      */
-    virtual std::vector<SegmentChoiceArrangementPick *> getPicks(const SegmentChoice *choice);
+    virtual std::vector<const SegmentChoiceArrangementPick *> getPicks(const SegmentChoice *choice);
 
     /**
      Get preferred (previously chosen) instrument audios
@@ -495,28 +495,28 @@ namespace XJ {
 
      @return Segment
      */
-    virtual Segment *getSegment();
+    virtual const Segment *getSegment();
 
     /**
      Get all segment chords, guaranteed to be in order of position ascending
 
      @return segment chords
      */
-    virtual std::vector<SegmentChord *> getSegmentChords();
+    virtual std::vector<const SegmentChord *> getSegmentChords();
 
     /**
      Get all segment chord voicings
 
      @return segment chord voicings
      */
-    virtual std::set<SegmentChordVoicing *> getChordVoicings();
+    virtual std::set<const SegmentChordVoicing *> getChordVoicings();
 
     /**
      Get all segment memes
 
      @return segment memes
      */
-    virtual std::set<SegmentMeme *> getSegmentMemes();
+    virtual std::set<const SegmentMeme *> getSegmentMemes();
 
     /**
      Get the sequence for a Choice either directly (beat- and detail-type sequences), or by sequence-pattern (macro- or main-type sequences) https://github.com/xjmusic/xjmusic/issues/204
@@ -592,7 +592,7 @@ namespace XJ {
      @param instrumentType for which to get voicing
      @return chord voicing for chord
      */
-    virtual std::optional<SegmentChordVoicing *>
+    virtual std::optional<const SegmentChordVoicing *>
     chooseVoicing(const SegmentChord *chord, Instrument::Type instrumentType);
 
     /**
@@ -706,7 +706,7 @@ namespace XJ {
      @return choice if successfully put
      @ on failure
      */
-    virtual std::optional<SegmentChoice *> put(SegmentChoice entity, bool force);
+    virtual std::optional<const SegmentChoice *> put(SegmentChoice entity, bool force);
 
     /**
      Put a SegmentChoiceArrangement in the store
@@ -715,7 +715,7 @@ namespace XJ {
      @return Arrangement successfully put
      @ on failure
      */
-    virtual SegmentChoiceArrangement *put(SegmentChoiceArrangement entity);
+    virtual const SegmentChoiceArrangement *put(SegmentChoiceArrangement entity);
 
     /**
      Put a SegmentChoiceArrangementPick in the store
@@ -724,7 +724,7 @@ namespace XJ {
      @return ChoiceArrangementPick successfully put
      @ on failure
      */
-    virtual SegmentChoiceArrangementPick *put(SegmentChoiceArrangementPick entity);
+    virtual const SegmentChoiceArrangementPick *put(SegmentChoiceArrangementPick entity);
 
     /**
      Put a SegmentChord in the store
@@ -733,7 +733,7 @@ namespace XJ {
      @return Chord successfully put
      @ on failure
      */
-    virtual SegmentChord* put(SegmentChord entity);
+    virtual const SegmentChord* put(SegmentChord entity);
 
     /**
      Put a SegmentChordVoicing in the store
@@ -742,7 +742,7 @@ namespace XJ {
      @return ChordVoicing successfully put
      @ on failure
      */
-    virtual SegmentChordVoicing* put(SegmentChordVoicing entity);
+    virtual const SegmentChordVoicing* put(SegmentChordVoicing entity);
 
     /**
      Put a SegmentMeme in the store
@@ -752,7 +752,7 @@ namespace XJ {
      @return Meme successfully put
      @ on failure
      */
-    virtual std::optional<SegmentMeme *> put(SegmentMeme entity, bool force);
+    virtual std::optional<const SegmentMeme *> put(SegmentMeme entity, bool force);
 
     /**
      Put a SegmentMessage in the store
@@ -761,7 +761,7 @@ namespace XJ {
      @return Message successfully put
      @ on failure
      */
-    virtual SegmentMessage *put(SegmentMessage entity);
+    virtual const SegmentMessage *put(SegmentMessage entity);
 
     /**
      Put a SegmentMeta in the store
@@ -770,7 +770,7 @@ namespace XJ {
      @return Meta successfully put
      @ on failure
      */
-    virtual SegmentMeta* put(SegmentMeta entity);
+    virtual const SegmentMeta* put(SegmentMeta entity);
 
     /**
      Set the preferred audio for a key
@@ -808,7 +808,7 @@ namespace XJ {
      @param segment to set
      @ on failure
      */
-    virtual Segment *updateSegment(Segment segment);
+    virtual const Segment *updateSegment(Segment segment);
 
     /**
      Get the Segment Retrospective
@@ -918,7 +918,7 @@ namespace XJ {
     std::map<std::string, NoteRange> rangeForChoice;
     std::map<std::string, std::optional<Note>> rootNotesByVoicingAndChord;
     std::map<UUID, std::vector<const ProgramSequenceChord *>> completeChordsForProgramSequence;
-    std::map<UUID, std::vector<SegmentChoiceArrangementPick*>> picksForChoice;
+    std::map<UUID, std::vector<const SegmentChoiceArrangementPick*>> picksForChoice;
     SegmentEntityStore *store;
     SegmentRetrospective *retrospective;
     std::set<UUID> boundInstrumentIds;
@@ -927,8 +927,8 @@ namespace XJ {
     int segmentId;
     std::optional<Segment::Type> type;
 
-    std::optional<SegmentChoice*> macroChoiceOfPreviousSegment;
-    std::optional<SegmentChoice*> mainChoiceOfPreviousSegment;
+    std::optional<const SegmentChoice*> macroChoiceOfPreviousSegment;
+    std::optional<const SegmentChoice*> mainChoiceOfPreviousSegment;
 
     double microsPerBeat{};
 

--- a/engine/include/xjmusic/fabricator/SegmentRetrospective.h
+++ b/engine/include/xjmusic/fabricator/SegmentRetrospective.h
@@ -59,12 +59,12 @@ namespace XJ {
      @return arrangement
      @ on failure to retrieve
      */
-    virtual SegmentChoiceArrangement *getArrangement(const SegmentChoiceArrangementPick *pick);
+    virtual const SegmentChoiceArrangement *getArrangement(const SegmentChoiceArrangementPick *pick);
 
     /**
      @return all choices
      */
-    virtual std::set<SegmentChoice *> getChoices();
+    virtual std::set<const SegmentChoice *> getChoices();
 
     /**
      Get the choice for the given arrangement
@@ -73,7 +73,7 @@ namespace XJ {
      @return choice
      @ on failure to retrieve
      */
-    virtual SegmentChoice *getChoice(const SegmentChoiceArrangement *arrangement);
+    virtual const SegmentChoice *getChoice(const SegmentChoiceArrangement *arrangement);
 
     /**
      Get the instrument type for a given pick
@@ -91,7 +91,7 @@ namespace XJ {
      @param key to search for meta
      @return meta if found
      */
-    virtual std::optional<SegmentMeta *> getPreviousMeta(const std::string &key);
+    virtual std::optional<const SegmentMeta *> getPreviousMeta(const std::string &key);
 
     /**
      Get the previous segment choices for the given instrument
@@ -100,7 +100,7 @@ namespace XJ {
      @param instrumentId for which to get choice
      @return previous segment choice
      */
-    virtual std::set<SegmentChoice *> getPreviousChoicesForInstrument(const UUID &instrumentId);
+    virtual std::set<const SegmentChoice *> getPreviousChoicesForInstrument(const UUID &instrumentId);
 
     /**
      Get the previous arrangements for the given instrument id
@@ -108,7 +108,7 @@ namespace XJ {
      @param instrumentId for which to get arrangements
      @return segment choice arrangements
      */
-    virtual std::set<SegmentChoiceArrangement *> getPreviousArrangementsForInstrument(UUID instrumentId);
+    virtual std::set<const SegmentChoiceArrangement *> getPreviousArrangementsForInstrument(UUID instrumentId);
 
     /**
      Get the picks of any previous segments which selected the same main sequence
@@ -117,7 +117,7 @@ namespace XJ {
 
      @return map of all previous segment meme constellations (as keys) to a collection of choices made
      */
-    virtual std::set<SegmentChoiceArrangementPick *> getPicks();
+    virtual std::set<const SegmentChoiceArrangementPick *> getPicks();
 
     /**
      Get the choice of a given type
@@ -126,7 +126,7 @@ namespace XJ {
      @param programType of choice to get
      @return choice of given type
      */
-    virtual std::optional<SegmentChoice *> getPreviousChoiceOfType(const Segment *segment, Program::Type programType);
+    virtual std::optional<const SegmentChoice *> getPreviousChoiceOfType(const Segment *segment, Program::Type programType);
 
     /**
      Get the previous-segment choice of a given type
@@ -134,7 +134,7 @@ namespace XJ {
      @param programType of choice to get
      @return choice of given type
      */
-    virtual std::optional<SegmentChoice *> getPreviousChoiceOfType(Program::Type programType);
+    virtual std::optional<const SegmentChoice *> getPreviousChoiceOfType(Program::Type programType);
 
     /**
      Get the previous-segment choices of a given instrument mode
@@ -142,7 +142,7 @@ namespace XJ {
      @param instrumentMode for which to get previous-segment choices
      @return choices
      */
-    virtual std::set<SegmentChoice *> getPreviousChoicesOfMode(Instrument::Mode instrumentMode);
+    virtual std::set<const SegmentChoice *> getPreviousChoicesOfMode(Instrument::Mode instrumentMode);
 
     /**
      Get the previous-segment choices of a given instrument type and mode
@@ -151,7 +151,7 @@ namespace XJ {
      @param instrumentMode for which to get previous-segment choices
      @return choices
      */
-    virtual std::set<SegmentChoice *>
+    virtual std::set<const SegmentChoice *>
     getPreviousChoicesOfTypeMode(Instrument::Type instrumentType, Instrument::Mode instrumentMode);
 
     /**
@@ -160,7 +160,7 @@ namespace XJ {
      @param instrumentType for which to get previous-segment choices
      @return choices
      */
-    virtual std::optional<SegmentChoice *> getPreviousChoiceOfType(Instrument::Type instrumentType);
+    virtual std::optional<const SegmentChoice *> getPreviousChoiceOfType(Instrument::Type instrumentType);
 
     /**
      Get the previous picks for the given instrument id
@@ -168,14 +168,14 @@ namespace XJ {
      @param instrumentId for which to get picks
      @return segment choice picks
      */
-    virtual std::set<SegmentChoiceArrangementPick *> getPreviousPicksForInstrument(UUID instrumentId);
+    virtual std::set<const SegmentChoiceArrangementPick *> getPreviousPicksForInstrument(UUID instrumentId);
 
     /**
      Get the segment immediately previous to the current segment
 
      @return previous segment
      */
-    virtual std::optional<Segment *> getPreviousSegment();
+    virtual std::optional<const Segment *> getPreviousSegment();
 
     /**
      @return all cached segments, ordered by id
@@ -185,7 +185,7 @@ namespace XJ {
      whether this retrospective is looking back on the current main program (Continue segment),
      or the previous one (NextMain/NextMacro segments)
      */
-    virtual std::vector<Segment *> getSegments();
+    virtual std::vector<const Segment *> getSegments();
 
     /**
      Get all segment chords for the given segment id, ordered by position
@@ -193,15 +193,15 @@ namespace XJ {
      @param segmentId for which to get chords
      @return chords
      */
-    virtual std::vector<SegmentChord *> getSegmentChords(int segmentId);
+    virtual std::vector<const SegmentChord *> getSegmentChords(int segmentId);
 
   private:
     int segmentId;
     SegmentEntityStore* entityStore{};
-    std::vector<Segment *> retroSegments{};
+    std::vector<const Segment *> retroSegments{};
     std::set<int> previousSegmentIds{};
-    std::optional<Segment *> previousSegment;
-    std::map<int, std::vector<SegmentChord *>> segmentChords{}; // indexed by id, vector of chords ordered by position
+    std::optional<const Segment *> previousSegment;
+    std::map<int, std::vector<const SegmentChord *>> segmentChords{}; // indexed by id, vector of chords ordered by position
   };
 
 }// namespace XJ

--- a/engine/include/xjmusic/fabricator/SegmentUtils.h
+++ b/engine/include/xjmusic/fabricator/SegmentUtils.h
@@ -31,7 +31,7 @@ namespace XJ {
      @return segment choice of given type
      */
     static std::optional<const SegmentChoice *>
-    findFirstOfType(const std::set<SegmentChoice *> &segmentChoices, Program::Type type);
+    findFirstOfType(const std::set<const SegmentChoice *> &segmentChoices, Program::Type type);
 
     /**
      Find first segment choice of a given type in a collection of segment choices
@@ -41,7 +41,7 @@ namespace XJ {
      @return segment choice of given type
      */
     static std::optional<const SegmentChoice *>
-    findFirstOfType(const std::set<SegmentChoice *> &segmentChoices, Instrument::Type type);
+    findFirstOfType(const std::set<const SegmentChoice *> &segmentChoices, Instrument::Type type);
 
     /**
      Get the identifier or a Segment: ship key if available, else ID
@@ -49,7 +49,7 @@ namespace XJ {
      @param segment to get identifier of
      @return ship key if available, else ID
      */
-    static std::string getIdentifier(Segment *segment);
+    static std::string getIdentifier(const Segment *segment);
 
     /**
      Get the last dubbed from any collection of Segments
@@ -57,7 +57,7 @@ namespace XJ {
      @param segments to get last dubbed from
      @return last dubbed segment from collection
      */
-    static std::optional<Segment *> getLastCrafted(const std::vector<Segment *> &segments);
+    static std::optional<const Segment *> getLastCrafted(const std::vector<const Segment *> &segments);
 
     /**
      Get the last from any collection of Segments
@@ -65,7 +65,7 @@ namespace XJ {
      @param segments to get last from
      @return last segment from collection
      */
-    static std::optional<Segment *> getLast(const std::vector<Segment *> &segments);
+    static std::optional<const Segment *> getLast(const std::vector<const Segment *> &segments);
 
     /**
      Get only the dubbed from any collection of Segments
@@ -73,7 +73,7 @@ namespace XJ {
      @param segments to get dubbed from
      @return dubbed segments from collection
      */
-    static std::vector<Segment *> getCrafted(const std::vector<Segment *> &segments);
+    static std::vector<const Segment *> getCrafted(const std::vector<const Segment *> &segments);
 
     /**
      Whether a segment chord voicing contains any valid notes

--- a/engine/include/xjmusic/segment/SegmentChord.h
+++ b/engine/include/xjmusic/segment/SegmentChord.h
@@ -35,7 +35,7 @@ namespace XJ {
      * @param segmentChords  The set of Segment Chords
      * @return       The names
      */
-    static std::set<std::string> getNames(const std::set<SegmentChord *> &segmentChords);
+    static std::set<std::string> getNames(const std::set<const SegmentChord *> &segmentChords);
   };
 
 }// namespace XJ

--- a/engine/include/xjmusic/segment/SegmentEntityStore.h
+++ b/engine/include/xjmusic/segment/SegmentEntityStore.h
@@ -79,7 +79,7 @@ namespace XJ {
      * Put the Chain in the entity store
      * @returns stored Chain
      */
-    Chain *put(const Chain &chain);
+    Chain *put(const Chain &c);
 
     /**
      * Put a Segment in the entity store

--- a/engine/include/xjmusic/segment/SegmentEntityStore.h
+++ b/engine/include/xjmusic/segment/SegmentEntityStore.h
@@ -22,11 +22,11 @@
 
 using namespace XJ;
 
-#define SEGMENT_STORE_CORE_HEADERS(ENTITY, ENTITIES)                     \
-  ENTITY *put(const ENTITY &choice);                                     \
-  std::optional<ENTITY *> read##ENTITY(int segmentId, const UUID &id);   \
-  std::set<ENTITY *> readAll##ENTITIES(int segmentId);                   \
-  std::set<ENTITY *> readAll##ENTITIES(const std::set<int> &segmentIds); \
+#define SEGMENT_STORE_CORE_HEADERS(ENTITY, ENTITIES)                           \
+  const ENTITY *put(const ENTITY &choice);                                     \
+  std::optional<const ENTITY *> read##ENTITY(int segmentId, const UUID &id);   \
+  std::set<const ENTITY *> readAll##ENTITIES(int segmentId);                   \
+  std::set<const ENTITY *> readAll##ENTITIES(const std::set<int> &segmentIds); \
   void delete##ENTITY(int segmentId, const UUID &id);
 
 
@@ -42,16 +42,18 @@ namespace XJ {
    */
   class SegmentEntityStore {
     std::optional<Chain> chain;
-    std::map<int, Segment> segments;
-    std::map<int, std::map<UUID, SegmentChoice>> segmentChoices;
-    std::map<int, std::map<UUID, SegmentChoiceArrangement>> segmentChoiceArrangements;
-    std::map<int, std::map<UUID, SegmentChoiceArrangementPick>> segmentChoiceArrangementPicks;
-    std::map<int, std::map<UUID, SegmentChord>> segmentChords;
-    std::map<int, std::map<UUID, SegmentChordVoicing>> segmentChordVoicings;
-    std::map<int, std::map<UUID, SegmentMeme>> segmentMemes;
-    std::map<int, std::map<UUID, SegmentMessage>> segmentMessages;
-    std::map<int, std::map<UUID, SegmentMeta>> segmentMetas;
+    std::map<int, const Segment> segments;
+    std::map<int, std::map<UUID, const SegmentChoice>> segmentChoices;
+    std::map<int, std::map<UUID, const SegmentChoiceArrangement>> segmentChoiceArrangements;
+    std::map<int, std::map<UUID, const SegmentChoiceArrangementPick>> segmentChoiceArrangementPicks;
+    std::map<int, std::map<UUID, const SegmentChord>> segmentChords;
+    std::map<int, std::map<UUID, const SegmentChordVoicing>> segmentChordVoicings;
+    std::map<int, std::map<UUID, const SegmentMeme>> segmentMemes;
+    std::map<int, std::map<UUID, const SegmentMessage>> segmentMessages;
+    std::map<int, std::map<UUID, const SegmentMeta>> segmentMetas;
+
     static void validate(SegmentMeme entity);
+
     static void validate(Segment entity);
 
   public:
@@ -83,7 +85,7 @@ namespace XJ {
      * Put a Segment in the entity store
      * @returns stored Segment
      */
-    Segment *put(const Segment &segment);
+    const Segment *put(const Segment &segment);
 
     /**
      * Read a Chain by #
@@ -95,7 +97,7 @@ namespace XJ {
      * Read a Segment by #
      * @returns requested Segment
      */
-    std::optional<Segment *> readSegment(int segmentId);
+    std::optional<const Segment *> readSegment(int segmentId);
 
     /**
      Get the segment at the given chain microseconds, if it is ready
@@ -106,7 +108,7 @@ namespace XJ {
      @param chainMicros the chain microseconds for which to get the segment
      @return the segment at the given chain microseconds, or an empty optional if the segment is not ready
      */
-    std::optional<Segment *> readSegmentAtChainMicros(long chainMicros);
+    std::optional<const Segment *> readSegmentAtChainMicros(long chainMicros);
 
     /**
     Get all segments for a chain id
@@ -114,7 +116,7 @@ namespace XJ {
     @return collection of segments
     @ on failure to retrieve the requested key
     */
-    std::vector<Segment *> readAllSegments();
+    std::vector<const Segment *> readAllSegments();
 
     /**
      Get all segments for a chain id in a given state
@@ -123,7 +125,7 @@ namespace XJ {
      @return collection of segments
      @throws exception on failure to retrieve the requested key
      */
-    std::vector<Segment *> readAllSegmentsInState(Segment::State segmentState);
+    std::vector<const Segment *> readAllSegmentsInState(Segment::State segmentState);
 
     /**
      Read all Segments that are accessible, by Chain ID, starting and ending at particular offsets
@@ -132,7 +134,7 @@ namespace XJ {
      @param toOffset   to read segments to
      @return list of segments as JSON
      */
-    std::vector<Segment> readSegmentsFromToOffset(int fromOffset, int toOffset);
+    std::vector<const Segment> readSegmentsFromToOffset(int fromOffset, int toOffset);
 
     /**
      Fetch all sub-entities records for many parent segments by id
@@ -140,7 +142,7 @@ namespace XJ {
      @param segmentIds to fetch records for.
      @return collection of all sub entities of these parent segments, different classes that extend EntityUtils
      */
-    std::set<SegmentEntity *> readAllSegmentEntities(const std::set<int> &segmentIds);
+    std::set<const SegmentEntity *> readAllSegmentEntities(const std::set<int> &segmentIds);
 
     /**
      Get the segments that span the given instant
@@ -172,7 +174,7 @@ namespace XJ {
      @param programType to get
      @return main choice
      */
-    std::optional<SegmentChoice *> readChoice(int segmentId, Program::Type programType);
+    std::optional<const SegmentChoice *> readChoice(int segmentId, Program::Type programType);
 
     /**
      Get a hash of all the choices for the given segment
@@ -187,7 +189,8 @@ namespace XJ {
     * @param segments    of segments
     * @return        list of choices
     */
-    std::set<const SegmentChoiceArrangementPick *> readAllSegmentChoiceArrangementPicks(const std::vector<const Segment *> &segments);
+    std::set<const SegmentChoiceArrangementPick *>
+    readAllSegmentChoiceArrangementPicks(const std::vector<const Segment *> &segments);
 
     /**
      Get the total number of segments in the store
@@ -209,7 +212,7 @@ namespace XJ {
      @param segment for the updated EntityUtils.
      @ on failure
      */
-    Segment *updateSegment(Segment &segment);
+    const Segment *updateSegment(Segment &segment);
 
     /**
      * Read a Chain by #

--- a/engine/include/xjmusic/segment/SegmentEntityStore.h
+++ b/engine/include/xjmusic/segment/SegmentEntityStore.h
@@ -42,15 +42,15 @@ namespace XJ {
    */
   class SegmentEntityStore {
     std::optional<Chain> chain;
-    std::map<int, const Segment> segments;
-    std::map<int, std::map<UUID, const SegmentChoice>> segmentChoices;
-    std::map<int, std::map<UUID, const SegmentChoiceArrangement>> segmentChoiceArrangements;
-    std::map<int, std::map<UUID, const SegmentChoiceArrangementPick>> segmentChoiceArrangementPicks;
-    std::map<int, std::map<UUID, const SegmentChord>> segmentChords;
-    std::map<int, std::map<UUID, const SegmentChordVoicing>> segmentChordVoicings;
-    std::map<int, std::map<UUID, const SegmentMeme>> segmentMemes;
-    std::map<int, std::map<UUID, const SegmentMessage>> segmentMessages;
-    std::map<int, std::map<UUID, const SegmentMeta>> segmentMetas;
+    std::map<int, Segment> segments;
+    std::map<int, std::map<UUID, SegmentChoice>> segmentChoices;
+    std::map<int, std::map<UUID, SegmentChoiceArrangement>> segmentChoiceArrangements;
+    std::map<int, std::map<UUID, SegmentChoiceArrangementPick>> segmentChoiceArrangementPicks;
+    std::map<int, std::map<UUID, SegmentChord>> segmentChords;
+    std::map<int, std::map<UUID, SegmentChordVoicing>> segmentChordVoicings;
+    std::map<int, std::map<UUID, SegmentMeme>> segmentMemes;
+    std::map<int, std::map<UUID, SegmentMessage>> segmentMessages;
+    std::map<int, std::map<UUID, SegmentMeta>> segmentMetas;
 
     static void validate(SegmentMeme entity);
 
@@ -134,7 +134,7 @@ namespace XJ {
      @param toOffset   to read segments to
      @return list of segments as JSON
      */
-    std::vector<const Segment> readSegmentsFromToOffset(int fromOffset, int toOffset);
+    std::vector<const Segment*> readSegmentsFromToOffset(int fromOffset, int toOffset);
 
     /**
      Fetch all sub-entities records for many parent segments by id
@@ -151,7 +151,7 @@ namespace XJ {
      @param toChainMicros   for which to get segments
      @return segments that span the given instant, empty if none found
      */
-    std::vector<Segment> readAllSegmentsSpanning(long fromChainMicros, long toChainMicros);
+    std::vector<const Segment*> readAllSegmentsSpanning(long fromChainMicros, long toChainMicros);
 
     /**
      Get the last known segment id
@@ -165,7 +165,7 @@ namespace XJ {
 
      @return Last Segment in Chain
      */
-    std::optional<Segment> readSegmentLast();
+    std::optional<const Segment*> readSegmentLast();
 
     /**
      Read a choice for a given segment id and program type

--- a/engine/include/xjmusic/segment/SegmentMeme.h
+++ b/engine/include/xjmusic/segment/SegmentMeme.h
@@ -34,7 +34,7 @@ namespace XJ {
      * @param segmentMemes  The set of Segment Memes
      * @return       The names
      */
-    static std::set<std::string> getNames(const std::set<SegmentMeme *> &segmentMemes);
+    static std::set<std::string> getNames(const std::set<const SegmentMeme *> &segmentMemes);
   };
 
 }// namespace XJ

--- a/engine/include/xjmusic/util/ValueUtils.h
+++ b/engine/include/xjmusic/util/ValueUtils.h
@@ -151,10 +151,9 @@ namespace XJ {
      * @param floor      bottom value
      * @param ceiling    top value
      * @param position   between 0 and 1 of value to interpolate between the floor and ceiling
-     * @param multiplier of value (above ceiling)
      * @return interpolated value
      */
-    static float interpolate(float floor, float ceiling, float position, float multiplier);
+    static float interpolate(float floor, float ceiling, float position);
 
     /**
      * Enforce a maximum

--- a/engine/include/xjmusic/util/ValueUtils.h
+++ b/engine/include/xjmusic/util/ValueUtils.h
@@ -28,6 +28,7 @@ namespace XJ {
     static long MICROS_PER_MILLI;
     static long NANOS_PER_MICRO;
     static long MICROS_PER_SECOND;
+    static float MICROS_PER_SECOND_FLOAT;
     static long NANOS_PER_SECOND;
     static long SECONDS_PER_MINUTE;
     static long MICROS_PER_MINUTE;

--- a/engine/include/xjmusic/work/CraftWork.h
+++ b/engine/include/xjmusic/work/CraftWork.h
@@ -58,7 +58,7 @@ namespace XJ {
 
     @return true if finished (not running)
     */
-   bool isFinished();
+   bool isFinished() const;
 
    /**
     This is the internal cycle that's run indefinitely
@@ -193,21 +193,21 @@ namespace XJ {
      * @param segment for which to get choices
      * @return  choices
      */
-    std::set<const SegmentChoice *> getChoices(const Segment *segment);
+    std::set<const SegmentChoice *> getChoices(const Segment *segment) const;
 
     /**
      * Get all arrangements for the given choice
      * @param choice for which to get arrangements
      * @return  arrangements
      */
-    std::set<const SegmentChoiceArrangement *> getArrangements(const SegmentChoice *choice);
+    std::set<const SegmentChoiceArrangement *> getArrangements(const SegmentChoice *choice) const;
 
     /**
      * Get all picks for the given arrangement
      * @param arrangement for which to get picks
      * @return  picks
      */
-    std::set<const SegmentChoiceArrangementPick *> getPicks(const SegmentChoiceArrangement *arrangement);
+    std::set<const SegmentChoiceArrangementPick *> getPicks(const SegmentChoiceArrangement *arrangement) const;
 
   private:
     /**

--- a/engine/include/xjmusic/work/CraftWork.h
+++ b/engine/include/xjmusic/work/CraftWork.h
@@ -95,7 +95,7 @@ namespace XJ {
      @param chainMicros the microseconds since beginning of chain for which to get the segment
      @return the segment at the given chain microseconds, or an empty optional if the segment is not ready
      */
-    std::optional<Segment *> getSegmentAtChainMicros(unsigned long long chainMicros) const;
+    std::optional<const Segment *> getSegmentAtChainMicros(unsigned long long chainMicros) const;
 
     /**
      Get the segment at the given offset, if it is ready
@@ -103,7 +103,7 @@ namespace XJ {
      @param offset of segment
      @return the segment at the given offset
      */
-    std::optional<Segment *> getSegmentAtOffset(int offset) const;
+    std::optional<const Segment *> getSegmentAtOffset(int offset) const;
 
     /**
      Get the segments spanning the given time range, if they are ready- if not, return an empty list
@@ -188,10 +188,52 @@ namespace XJ {
      */
     bool getAndResetDidOverride();
 
+    /**
+     * Get all choices for the given segment
+     * @param segment for which to get choices
+     * @return  choices
+     */
+    std::set<const SegmentChoice *> getChoices(const Segment *segment);
+
+    /**
+     * Get all arrangements for the given choice
+     * @param choice for which to get arrangements
+     * @return  arrangements
+     */
+    std::set<const SegmentChoiceArrangement *> getArrangements(const SegmentChoice *choice);
+
+    /**
+     * Get all picks for the given arrangement
+     * @param arrangement for which to get picks
+     * @return  picks
+     */
+    std::set<const SegmentChoiceArrangementPick *> getPicks(const SegmentChoiceArrangement *arrangement);
+
   private:
+    /**
+     Bootstrap a chain from JSON chain bootstrap data.
+     */
     const Chain *createChainForTemplate(const Template *tmpl) const;
+
+    /**
+     Log and send notification of error that job failed while (message)
+    
+     @param msgWhile phrased like "Doing work"
+     @param e        exception (optional)
+     */
     void didFailWhile(std::string msgWhile, const std::exception &e);
-    static void updateSegmentState(Fabricator *fabricator, Segment *segment, Segment::State fromState, Segment::State toState);
+
+    /**
+     Update Segment to Working state
+    
+     @param fabricator to update
+     @param inputSegment    to update
+     @param fromState  of existing segment
+     @param toState    of new segment
+     @ if record is invalid
+     */
+    static const Segment *
+    updateSegmentState(Fabricator *fabricator, const Segment *inputSegment, const Segment::State fromState, const Segment::State toState);
 
    /**
     Fabricate the chain based on craft state
@@ -232,25 +274,44 @@ namespace XJ {
    /**
     Cut the current segment short after the given number of beats
 
-    @param segment          to cut short
+    @param inputSegment          segment to cut short
     @param cutoffAfterBeats number of beats to cut short after
     */
-   void doCutoffLastSegment(Segment *segment, double cutoffAfterBeats) const;
+   void doCutoffLastSegment(const Segment *inputSegment, float cutoffAfterBeats) const;
 
    /**
     Craft a Segment, or fail
 
-    @param segment              to craft
+    @param inputSegment              to craft
     @param overrideSegmentType  to use for crafting
     @param overrideMacroProgram to override fabrication
     @param overrideMemes        to override fabrication
     @ on configuration failure
     @ on craft failure
     */
-   void doFabricationWork(Segment *segment, std::optional<Segment::Type> overrideSegmentType, const std::optional<const Program *> overrideMacroProgram, const std::set<std::string> &overrideMemes) const;
+   void doFabricationWork(const Segment *inputSegment, std::optional<Segment::Type> overrideSegmentType, const std::optional<const Program *> overrideMacroProgram, const std::set<std::string> &overrideMemes) const;
+
+    /**
+     Delete segments before the given shipped-to chain micros
+    
+     @param shippedToChainMicros the shipped-to chain micros
+     */
    void doSegmentCleanup(long shippedToChainMicros) const;
-   Segment *buildSegmentInitial() const;
-   Segment *buildSegmentFollowing(const Segment *last) const;
+
+    /**
+     Create the initial template segment
+    
+     @return initial template segment
+     */
+   Segment buildSegmentInitial() const;
+
+    /**
+     Create the next segment in the chain, following the last segment
+    
+     @param last segment
+     @return next segment
+     */
+   Segment buildSegmentFollowing(const Segment *last) const;
 
    /**
     If memes/macro already engaged at fabrication start (which is always true in a manual control mode),

--- a/engine/include/xjmusic/work/DubWork.h
+++ b/engine/include/xjmusic/work/DubWork.h
@@ -79,7 +79,7 @@ namespace XJ {
      @param atChainMicros the chain micros
      @return the segment, or empty if not yet available
      */
-    std::optional<Segment *> getSegmentAtChainMicros(long atChainMicros) const;
+    std::optional<const Segment *> getSegmentAtChainMicros(long atChainMicros) const;
 
     /**
      Get the segment at the given offset
@@ -87,7 +87,7 @@ namespace XJ {
      @param offset the offset
      @return the segment, or empty if not yet available
      */
-    std::optional<Segment *> getSegmentAtOffset(int offset) const;
+    std::optional<const Segment *> getSegmentAtOffset(int offset) const;
 
     /**
      Get the main program for the given segment

--- a/engine/src/audio/ActiveAudio.cpp
+++ b/engine/src/audio/ActiveAudio.cpp
@@ -8,14 +8,14 @@ ActiveAudio::ActiveAudio(
     const SegmentChoiceArrangementPick* pick,
     const Instrument *instrument,
     const InstrumentAudio* audio,
-    unsigned long long startAtMixerMicros,
-    std::optional<unsigned long long> stopAtMixerMicros,
+    unsigned long long startAtChainMicros,
+    std::optional<unsigned long long> stopAtChainMicros,
     float fromIntensityAmplitude,
     float toIntensityAmplitude) {
   this->pick = pick;
   this->audio = audio;
-  this->startAtMixerMicros = startAtMixerMicros;
-  this->stopAtMixerMicros = stopAtMixerMicros;
+  this->startAtChainMicros = startAtChainMicros;
+  this->stopAtChainMicros = stopAtChainMicros;
   this->instrument = instrument;
 
   // computed
@@ -36,12 +36,12 @@ const Instrument * ActiveAudio::getInstrument() {
   return instrument;
 }
 
-unsigned long long ActiveAudio::getStartAtMixerMicros() const {
-  return startAtMixerMicros;
+unsigned long long ActiveAudio::getStartAtChainMicros() const {
+  return startAtChainMicros;
 }
 
-std::optional<unsigned long long> ActiveAudio::getStopAtMixerMicros() const {
-  return stopAtMixerMicros;
+std::optional<unsigned long long> ActiveAudio::getStopAtChainMicros() const {
+  return stopAtChainMicros;
 }
 
 const InstrumentAudio * ActiveAudio::getAudio() {

--- a/engine/src/craft/MacroMainCraft.cpp
+++ b/engine/src/craft/MacroMainCraft.cpp
@@ -69,23 +69,24 @@ void MacroMainCraft::doWork() const {
   }
 
   // Update the segment with fabricated content
-  segment->type = fabricator->getType();
-  segment->tempo = mainProgram->tempo;
-  segment->key = computeSegmentKey(mainSequence);
-  segment->total = mainSequence->total;
-  segment->durationMicros = segmentLengthMicros(mainProgram, mainSequence);
+  Segment updatedSegment = *segment;
+  updatedSegment.type = fabricator->getType();
+  updatedSegment.tempo = mainProgram->tempo;
+  updatedSegment.key = computeSegmentKey(mainSequence);
+  updatedSegment.total = mainSequence->total;
+  updatedSegment.durationMicros = segmentLengthMicros(mainProgram, mainSequence);
 
   // If the type is not Continue, we will reset the offset main
   if (Segment::Type::Continue == fabricator->getType())
-    segment->delta = segment->delta + segment->total;
+    updatedSegment.delta = segment->delta + segment->total;
   else
-    segment->delta = 0;
+    updatedSegment.delta = 0;
 
   // Set the intensity
-  segment->intensity = computeSegmentIntensity(segment->delta, macroSequence, mainSequence);
+  updatedSegment.intensity = computeSegmentIntensity(segment->delta, macroSequence, mainSequence);
 
   // Finished
-  fabricator->updateSegment(*segment);
+  fabricator->updateSegment(updatedSegment);
 }
 
 const ProgramSequence *MacroMainCraft::doMacroChoiceWork(const Segment *segment) const {

--- a/engine/src/craft/MacroMainCraft.cpp
+++ b/engine/src/craft/MacroMainCraft.cpp
@@ -1,7 +1,7 @@
 // Copyright (c) XJ Music Inc. (https://xjmusic.com) All Rights Reserved.
 
-#include "xjmusic/util/ValueUtils.h"
 #include "xjmusic/craft/MacroMainCraft.h"
+#include "xjmusic/util/ValueUtils.h"
 
 using namespace XJ;
 
@@ -113,7 +113,7 @@ const ProgramSequence *MacroMainCraft::doMacroChoiceWork(const Segment *segment)
   macroChoice.deltaOut = SegmentChoice::DELTA_UNLIMITED;
   macroChoice.programType = Program::Type::Macro;
   macroChoice.programSequenceBindingId = macroSequenceBinding.value()->id;
-  fabricator->put(macroChoice, true); // force put, because fabrication cannot proceed without a macro choice
+  fabricator->put(macroChoice, true);// force put, because fabrication cannot proceed without a macro choice
 
   return macroSequence.value();
 }
@@ -143,7 +143,7 @@ const ProgramSequence *MacroMainCraft::doMainChoiceWork(const Segment *segment) 
   mainChoice.deltaOut = SegmentChoice::DELTA_UNLIMITED;
   mainChoice.programType = Program::Type::Main;
   mainChoice.programSequenceBindingId = mainSequenceBinding.value()->id;
-  fabricator->put(mainChoice, true); // force put, because fabrication cannot proceed without a main choice
+  fabricator->put(mainChoice, true);// force put, because fabrication cannot proceed without a main choice
 
   return mainSequence.value();
 }
@@ -160,20 +160,17 @@ std::string MacroMainCraft::computeSegmentKey(const ProgramSequence *mainSequenc
   return Chord::of(mainKey).getName();
 }
 
-double MacroMainCraft::computeSegmentIntensity(
+float MacroMainCraft::computeSegmentIntensity(
     const int delta,
     const std::optional<const ProgramSequence *> macroSequence,
     const std::optional<const ProgramSequence *> mainSequence) const {
-  return fabricator->getTemplateConfig().intensityAutoCrescendoEnabled
-         ?
-         ValueUtils::limitDecimalPrecision(ValueUtils::interpolate(
-             fabricator->getTemplateConfig().intensityAutoCrescendoMinimum,
-             fabricator->getTemplateConfig().intensityAutoCrescendoMaximum,
-             static_cast<double>(delta) / fabricator->getTemplateConfig().mainProgramLengthMaxDelta,
-             computeIntensity(macroSequence, mainSequence)
-         ))
-         :
-         computeIntensity(macroSequence, mainSequence);
+  auto programmaticIntensity = computeIntensity(macroSequence, mainSequence);
+  if (!fabricator->getTemplateConfig().intensityAutoCrescendoEnabled) return programmaticIntensity;
+  return ValueUtils::interpolate(
+      fabricator->getTemplateConfig().intensityAutoCrescendoMinimum,
+      fabricator->getTemplateConfig().intensityAutoCrescendoMinimum +
+          (fabricator->getTemplateConfig().intensityAutoCrescendoMaximum - fabricator->getTemplateConfig().intensityAutoCrescendoMinimum) * programmaticIntensity,
+      delta / fabricator->getTemplateConfig().mainProgramLengthMaxDelta);
 }
 
 float MacroMainCraft::computeIntensity(
@@ -183,7 +180,7 @@ float MacroMainCraft::computeIntensity(
                                                                               macroSequence.value()->intensity)
                                                                         : std::nullopt;
   const std::optional<float> mainIntensity = mainSequence.has_value() ? std::optional(mainSequence.value()->intensity)
-                                                                : std::nullopt;
+                                                                      : std::nullopt;
   if (macroIntensity.has_value() && mainIntensity.has_value())
     return (macroIntensity.value() + mainIntensity.value()) / 2;
   if (macroIntensity.has_value())
@@ -283,8 +280,7 @@ const Program *MacroMainCraft::chooseMacroProgram() const {
   if (fabricator->isInitialSegment()) return chooseRandomProgram(candidates, {});
 
   // if continuing the macro program, use the same one
-  if (fabricator->isContinuationOfMacroProgram()
-      && fabricator->getMacroChoiceOfPreviousSegment().has_value()) {
+  if (fabricator->isContinuationOfMacroProgram() && fabricator->getMacroChoiceOfPreviousSegment().has_value()) {
     auto previousProgram = fabricator->getProgram(fabricator->getMacroChoiceOfPreviousSegment().value());
     if (!previousProgram.has_value()) {
       auto message =
@@ -298,8 +294,7 @@ const Program *MacroMainCraft::chooseMacroProgram() const {
 
   // Compute the meme isometry for use in selecting programs from the bag
   MemeIsometry iso =
-      !overrideMemes.empty() ?
-      MemeIsometry::of(fabricator->getMemeTaxonomy(), overrideMemes)
+      !overrideMemes.empty() ? MemeIsometry::of(fabricator->getMemeTaxonomy(), overrideMemes)
                              : fabricator->getMemeIsometryOfNextSequenceInPreviousMacro();
 
   // Compute any program id to avoid
@@ -354,11 +349,9 @@ const Program *MacroMainCraft::chooseMainProgram() const {
   auto candidates = fabricator->getSourceMaterial()->getProgramsOfType(Program::Type::Main);
 
   // if continuing the macro program, use the same one
-  if (Segment::Type::Continue == fabricator->getType()
-      && fabricator->getPreviousMainChoice().has_value()) {
+  if (Segment::Type::Continue == fabricator->getType() && fabricator->getPreviousMainChoice().has_value()) {
     auto previousChoice = fabricator->getPreviousMainChoice();
-    auto previousProgram = previousChoice.has_value() ?
-                           fabricator->getProgram(fabricator->getPreviousMainChoice().value())
+    auto previousProgram = previousChoice.has_value() ? fabricator->getProgram(fabricator->getPreviousMainChoice().value())
                                                       : std::nullopt;
     if (!previousProgram.has_value()) {
       auto message =

--- a/engine/src/fabricator/ChainUtils.cpp
+++ b/engine/src/fabricator/ChainUtils.cpp
@@ -34,7 +34,7 @@ std::string ChainUtils::getShipKey(const std::string &chainKey, const std::strin
 }
 
 
-long ChainUtils::computeFabricatedToChainMicros(const std::vector<Segment *> &segments) {
+long ChainUtils::computeFabricatedToChainMicros(const std::vector<const Segment *> &segments) {
   const auto lastDubbedSegment = SegmentUtils::getLastCrafted(segments);
   if (lastDubbedSegment.has_value()) {
     return lastDubbedSegment.value()->durationMicros.has_value() ? lastDubbedSegment.value()->beginAtChainMicros +

--- a/engine/src/fabricator/Fabricator.cpp
+++ b/engine/src/fabricator/Fabricator.cpp
@@ -98,19 +98,19 @@ void Fabricator::deletePick(const UUID &id) {
 }
 
 
-std::set<SegmentChoiceArrangement *> Fabricator::getArrangements() {
+std::set<const SegmentChoiceArrangement *> Fabricator::getArrangements() {
   return store->readAllSegmentChoiceArrangements(segmentId);
 }
 
 
-std::set<SegmentChoiceArrangement *> Fabricator::getArrangements(std::set<const SegmentChoice *> &choices) {
+std::set<const SegmentChoiceArrangement *> Fabricator::getArrangements(std::set<const SegmentChoice *> &choices) {
   std::vector<UUID> choiceIds;
   for (const auto &choice: choices) {
     choiceIds.push_back(choice->id);
   }
 
-  const std::set<SegmentChoiceArrangement *> allArrangements = getArrangements();
-  std::set<SegmentChoiceArrangement *> filteredArrangements;
+  const std::set<const SegmentChoiceArrangement *> allArrangements = getArrangements();
+  std::set<const SegmentChoiceArrangement *> filteredArrangements;
 
   for (const auto &arrangement: allArrangements) {
     if (std::find(choiceIds.begin(), choiceIds.end(), arrangement->segmentChoiceId) != choiceIds.end()) {
@@ -132,17 +132,17 @@ TemplateConfig Fabricator::getTemplateConfig() {
 }
 
 
-std::set<SegmentChoice *> Fabricator::getChoices() const {
+std::set<const SegmentChoice *> Fabricator::getChoices() const {
   return store->readAllSegmentChoices(segmentId);
 }
 
 
-std::optional<SegmentChord *> Fabricator::getChordAt(const float position) {
-  std::optional<SegmentChord *> foundChord;
+std::optional<const SegmentChord *> Fabricator::getChordAt(const float position) {
+  std::optional<const SegmentChord *> foundChord;
   float foundPosition = -1.0f;// Initialize with a negative value
 
   // We assume that these entities are in order of position ascending
-  std::vector<SegmentChord *> segmentChords = getSegmentChords();
+  std::vector<const SegmentChord *> segmentChords = getSegmentChords();
   for (const auto &segmentChord: segmentChords) {
     // If it's a better match (or no match has yet been found) then use it
     if (foundPosition < 0 || (segmentChord->position > foundPosition && segmentChord->position <= position)) {
@@ -160,7 +160,7 @@ std::optional<const SegmentChoice *> Fabricator::getCurrentMainChoice() {
 
 
 std::set<const SegmentChoice *> Fabricator::getCurrentDetailChoices() {
-  const std::set<SegmentChoice *> allChoices = getChoices();
+  std::set<const SegmentChoice *> allChoices = getChoices();
   std::set<const SegmentChoice *> detailChoices;
 
   for (const auto &choice: allChoices) {
@@ -229,7 +229,7 @@ std::optional<const SegmentChoice *> Fabricator::getChoiceIfContinued(const Prog
 }
 
 
-std::optional<SegmentChoice *> Fabricator::getChoiceIfContinued(const Instrument::Type instrumentType) {
+std::optional<const SegmentChoice *> Fabricator::getChoiceIfContinued(const Instrument::Type instrumentType) {
   if (getSegment()->type != Segment::Type::Continue) return std::nullopt;
 
   auto choices = retrospective->getChoices();
@@ -247,7 +247,7 @@ std::optional<SegmentChoice *> Fabricator::getChoiceIfContinued(const Instrument
 }
 
 
-std::optional<SegmentChoice *>
+std::optional<const SegmentChoice *>
 Fabricator::getChoiceIfContinued(const Instrument::Type instrumentType, const Instrument::Mode instrumentMode) {
   if (getSegment()->type != Segment::Type::Continue) return std::nullopt;
 
@@ -266,10 +266,10 @@ Fabricator::getChoiceIfContinued(const Instrument::Type instrumentType, const In
 }
 
 
-std::set<SegmentChoice *> Fabricator::getChoicesIfContinued(const Program::Type programType) {
+std::set<const SegmentChoice *> Fabricator::getChoicesIfContinued(const Program::Type programType) {
   if (getSegment()->type != Segment::Type::Continue) return {};
 
-  std::set<SegmentChoice *> filteredChoices;
+  std::set<const SegmentChoice *> filteredChoices;
 
   for (auto choice : retrospective->getChoices())
     if (choice->programType == programType)
@@ -309,13 +309,13 @@ std::optional<const ProgramSequence *> Fabricator::getProgramSequence(const Segm
 }
 
 
-std::optional<SegmentChoice *> Fabricator::getMacroChoiceOfPreviousSegment() {
+std::optional<const SegmentChoice *> Fabricator::getMacroChoiceOfPreviousSegment() {
   if (!macroChoiceOfPreviousSegment.has_value())
     macroChoiceOfPreviousSegment = retrospective->getPreviousChoiceOfType(Program::Type::Macro);
   return macroChoiceOfPreviousSegment;
 }
 
-std::optional<SegmentChoice *> Fabricator::getPreviousMainChoice() {
+std::optional<const SegmentChoice *> Fabricator::getPreviousMainChoice() {
   if (!mainChoiceOfPreviousSegment.has_value())
     mainChoiceOfPreviousSegment = retrospective->getPreviousChoiceOfType(Program::Type::Main);
   return mainChoiceOfPreviousSegment;
@@ -409,12 +409,12 @@ std::vector<std::string> Fabricator::getNotes(const SegmentChordVoicing *voicing
 }
 
 
-std::set<SegmentChoiceArrangementPick *> Fabricator::getPicks() {
+std::set<const SegmentChoiceArrangementPick *> Fabricator::getPicks() {
   return store->readAllSegmentChoiceArrangementPicks(segmentId);
 }
 
 
-std::vector<SegmentChoiceArrangementPick *> Fabricator::getPicks(const SegmentChoice *choice) {
+std::vector<const SegmentChoiceArrangementPick *> Fabricator::getPicks(const SegmentChoice *choice) {
   if (picksForChoice.find(choice->id) == picksForChoice.end()) {
     std::vector<UUID> arrangementIds;
     const auto arrangements = getArrangements();
@@ -423,7 +423,7 @@ std::vector<SegmentChoiceArrangementPick *> Fabricator::getPicks(const SegmentCh
         arrangementIds.push_back(arrangement->id);
       }
     }
-    std::vector<SegmentChoiceArrangementPick *> picks;
+    std::vector<const SegmentChoiceArrangementPick *> picks;
     const auto allPicks = getPicks();
     for (const auto &pick: allPicks) {
       if (std::find(arrangementIds.begin(), arrangementIds.end(), pick->segmentChoiceArrangementId) !=
@@ -436,7 +436,7 @@ std::vector<SegmentChoiceArrangementPick *> Fabricator::getPicks(const SegmentCh
               [](const SegmentChoiceArrangementPick *a, const SegmentChoiceArrangementPick *b) {
                 return a->startAtSegmentMicros < b->startAtSegmentMicros;
               });
-    picksForChoice[choice->id] = picks;
+    picksForChoice.emplace(choice->id, picks);
   }
   return picksForChoice[choice->id];
 }
@@ -710,7 +710,7 @@ long Fabricator::getTotalSegmentMicros() {
 }
 
 
-Segment *Fabricator::getSegment() {
+const Segment *Fabricator::getSegment() {
   const auto seg = store->readSegment(segmentId);
   if (!seg.has_value())
     throw FabricationFatalException("No segment found");
@@ -718,7 +718,7 @@ Segment *Fabricator::getSegment() {
 }
 
 
-std::vector<SegmentChord *> Fabricator::getSegmentChords() {
+std::vector<const SegmentChord *> Fabricator::getSegmentChords() {
   auto chords = store->readAllSegmentChords(segmentId);
   auto sortedChords = std::vector(chords.begin(), chords.end());
   std::sort(sortedChords.begin(), sortedChords.end(), [](const SegmentChord *a, const SegmentChord *b) {
@@ -728,12 +728,12 @@ std::vector<SegmentChord *> Fabricator::getSegmentChords() {
 }
 
 
-std::set<SegmentChordVoicing *> Fabricator::getChordVoicings() {
+std::set<const SegmentChordVoicing *> Fabricator::getChordVoicings() {
   return store->readAllSegmentChordVoicings(segmentId);
 }
 
 
-std::set<SegmentMeme *> Fabricator::getSegmentMemes() {
+std::set<const SegmentMeme *> Fabricator::getSegmentMemes() {
   return store->readAllSegmentMemes(segmentId);
 }
 
@@ -788,11 +788,11 @@ Segment::Type Fabricator::getType() {
 }
 
 
-std::optional<SegmentChordVoicing *>
+std::optional<const SegmentChordVoicing *>
 Fabricator::chooseVoicing(const SegmentChord *chord, const Instrument::Type instrumentType) {
-  const std::set<SegmentChordVoicing *> voicings = store->readAllSegmentChordVoicings(segmentId);
+  const std::set<const SegmentChordVoicing *> voicings = store->readAllSegmentChordVoicings(segmentId);
 
-  std::vector<SegmentChordVoicing *> validVoicings;
+  std::vector<const SegmentChordVoicing *> validVoicings;
   for (auto voicing: voicings) {
     if (SegmentUtils::containsAnyValidNotes(voicing) && voicing->type == instrumentType &&
         voicing->segmentChordId == chord->id) {
@@ -882,38 +882,38 @@ bool Fabricator::isInitialSegment() {
 }
 
 
-std::optional<SegmentChoice *> Fabricator::put(const SegmentChoice entity, const bool force) {
+std::optional<const SegmentChoice *> Fabricator::put(const SegmentChoice entity, const bool force) {
   const auto memeStack = MemeStack::from(templateConfig.memeTaxonomy, SegmentMeme::getNames(getSegmentMemes()));
 
   // For a SegmentChoice, add memes from program, program sequence binding, and instrument if present
   if (!isValidChoiceAndMemesHaveBeenAdded(entity, memeStack, force))
     return std::nullopt;
 
-   return store->put(entity);
+   return {store->put(entity)};
 }
 
 
-SegmentChoiceArrangement* Fabricator::put(const SegmentChoiceArrangement entity) {
+const SegmentChoiceArrangement* Fabricator::put(const SegmentChoiceArrangement entity) {
   return store->put(entity);
 }
 
 
-SegmentChoiceArrangementPick* Fabricator::put(const SegmentChoiceArrangementPick entity) {
+const SegmentChoiceArrangementPick* Fabricator::put(const SegmentChoiceArrangementPick entity) {
   return store->put(entity);
 }
 
 
-SegmentChord* Fabricator::put(const SegmentChord entity) {
+const SegmentChord* Fabricator::put(const SegmentChord entity) {
   return store->put(entity);
 }
 
 
-SegmentChordVoicing* Fabricator::put(const SegmentChordVoicing entity) {
+const SegmentChordVoicing* Fabricator::put(const SegmentChordVoicing entity) {
   return store->put(entity);
 }
 
 
-std::optional<SegmentMeme  *> Fabricator::put(const SegmentMeme entity, const bool force) {
+std::optional<const SegmentMeme  *> Fabricator::put(const SegmentMeme entity, const bool force) {
   const auto memeStack = MemeStack::from(templateConfig.memeTaxonomy, SegmentMeme::getNames(getSegmentMemes()));
 
   // Unless forced, don't put a duplicate of an existing meme
@@ -924,12 +924,12 @@ std::optional<SegmentMeme  *> Fabricator::put(const SegmentMeme entity, const bo
 }
 
 
-SegmentMessage * Fabricator::put(const SegmentMessage entity) {
+const SegmentMessage * Fabricator::put(const SegmentMessage entity) {
   return store->put(entity);
 }
 
 
-SegmentMeta * Fabricator::put(const SegmentMeta entity) {
+const SegmentMeta * Fabricator::put(const SegmentMeta entity) {
   return store->put(entity);
 }
 
@@ -953,7 +953,7 @@ void Fabricator::putReport(const std::string &key, const std::string &value) {
 }
 
 
-Segment *Fabricator::updateSegment(Segment segment) {
+const Segment *Fabricator::updateSegment(Segment segment) {
   try {
     return store->updateSegment(segment);
 
@@ -1006,7 +1006,7 @@ double Fabricator::getTempo() {
 
 
 std::optional<const SegmentMeta *> Fabricator::getSegmentMeta(const std::string &key) const {
-  const std::set<SegmentMeta *> allMetas = store->readAllSegmentMetas(segmentId);
+  const std::set<const SegmentMeta *> allMetas = store->readAllSegmentMetas(segmentId);
   for (const auto &meta: allMetas) {
     if (meta->key == key) {
       return meta;
@@ -1031,7 +1031,7 @@ std::optional<const SegmentChoice *> Fabricator::getChoiceOfType(Program::Type p
 
 
 std::set<const SegmentChoice *> Fabricator::getBeatChoices() const {
-  const std::set<SegmentChoice *> allChoices = getChoices();
+  const std::set<const SegmentChoice *> allChoices = getChoices();
   std::set<const SegmentChoice *> beatChoices;
 
   for (const auto &choice: allChoices) {
@@ -1072,13 +1072,14 @@ std::string Fabricator::computeShipKey(const Chain *chain, const Segment *segmen
 
 void Fabricator::ensureShipKey() {
   if (getSegment()->storageKey.empty()) {
-    const auto seg = getSegment();
+    const auto originalSegment = getSegment();
     const auto chainOpt = store->readChain();
     if (!chainOpt.has_value()) {
       throw FabricationException("No chain");
     }
-    seg->storageKey = computeShipKey(chainOpt.value(), getSegment());
-    updateSegment(*seg);
+    Segment updatedSegment = *originalSegment;
+    updatedSegment.storageKey = computeShipKey(chainOpt.value(), getSegment());
+    updateSegment(updatedSegment);
 
     spdlog::debug("[seg-{}] Generated ship key {}", segmentId, getSegment()->storageKey);
   }
@@ -1090,13 +1091,13 @@ Segment::Type Fabricator::computeType() {
     return Segment::Type::Initial;
 
   // previous main choice having at least one more pattern?
-  const std::optional<SegmentChoice *> previousMainChoice = getPreviousMainChoice();
+  const std::optional<const SegmentChoice *> previousMainChoice = getPreviousMainChoice();
 
   if (previousMainChoice.has_value() && hasOneMoreSequenceBindingOffset(previousMainChoice.value()) && getTemplateConfig().mainProgramLengthMaxDelta > getPreviousSegmentDelta())
     return Segment::Type::Continue;
 
   // previous macro choice having at least two more patterns?
-  const std::optional<SegmentChoice *> previousMacroChoice = getMacroChoiceOfPreviousSegment();
+  const std::optional<const SegmentChoice *> previousMacroChoice = getMacroChoiceOfPreviousSegment();
 
   if (previousMacroChoice.has_value() && hasTwoMoreSequenceBindingOffsets(previousMacroChoice.value()))
     return Segment::Type::NextMain;

--- a/engine/src/fabricator/SegmentRetrospective.cpp
+++ b/engine/src/fabricator/SegmentRetrospective.cpp
@@ -21,7 +21,7 @@ void SegmentRetrospective::load() {
   // only can build retrospective if there is at least one previous segment
   // the previous segment is the first one cached here. we may cache even further back segments below if found
   if (segmentId <= 0) {
-    retroSegments = std::vector<Segment *>();
+    retroSegments = std::vector<const Segment *>();
     previousSegmentIds = std::set<int>();
     previousSegment = std::nullopt;
     return;
@@ -36,7 +36,7 @@ void SegmentRetrospective::load() {
   }
 
   // previous segment must have a main choice to continue past here.
-  const std::optional<SegmentChoice *> previousSegmentMainChoice =
+  const std::optional<const SegmentChoice *> previousSegmentMainChoice =
       entityStore->readChoice(previousSegment.value()->id, Program::Type::Main);
 
   if (!previousSegmentMainChoice.has_value() || previousSegmentMainChoice.value()->programType != Program::Type::Main) {
@@ -53,28 +53,28 @@ void SegmentRetrospective::load() {
   }
 }
 
-std::optional<SegmentChoice *>
+std::optional<const SegmentChoice *>
 SegmentRetrospective::getPreviousChoiceOfType(const Segment *segment, const Program::Type programType) {
   const auto c = entityStore->readChoice(segment->id, programType);
   return c.has_value() && programType == c.value()->programType ? c : std::nullopt;
 }
 
-std::set<SegmentChoiceArrangementPick *> SegmentRetrospective::getPicks() {
+std::set<const SegmentChoiceArrangementPick *> SegmentRetrospective::getPicks() {
   // return new ArrayList<>(retroStore.getAll(SegmentChoiceArrangementPick.class));
   return entityStore->readAllSegmentChoiceArrangementPicks(previousSegmentIds);
 }
 
-std::optional<Segment *> SegmentRetrospective::getPreviousSegment() {
+std::optional<const Segment *> SegmentRetrospective::getPreviousSegment() {
   return previousSegment;
 }
 
-std::optional<SegmentChoice *> SegmentRetrospective::getPreviousChoiceOfType(const Program::Type programType) {
+std::optional<const SegmentChoice *> SegmentRetrospective::getPreviousChoiceOfType(const Program::Type programType) {
   if (!previousSegment.has_value()) return std::nullopt;
   return getPreviousChoiceOfType(previousSegment.value(), programType);
 }
 
-std::set<SegmentChoice *> SegmentRetrospective::getPreviousChoicesOfMode(const Instrument::Mode instrumentMode) {
-  std::set<SegmentChoice *> result;
+std::set<const SegmentChoice *> SegmentRetrospective::getPreviousChoicesOfMode(const Instrument::Mode instrumentMode) {
+  std::set<const SegmentChoice *> result;
   if (!previousSegment.has_value()) return result;
   const auto choices = entityStore->readAllSegmentChoices(previousSegment.value()->id);
   for (const auto &choice: choices) {
@@ -85,9 +85,9 @@ std::set<SegmentChoice *> SegmentRetrospective::getPreviousChoicesOfMode(const I
   return result;
 }
 
-std::set<SegmentChoice *>
+std::set<const SegmentChoice *>
 SegmentRetrospective::getPreviousChoicesOfTypeMode(const Instrument::Type instrumentType, const Instrument::Mode instrumentMode) {
-  std::set<SegmentChoice *> result;
+  std::set<const SegmentChoice *> result;
   if (!previousSegment.has_value()) return result;
   const auto choices = entityStore->readAllSegmentChoices(previousSegment.value()->id);
   for (const auto &choice: choices) {
@@ -98,7 +98,7 @@ SegmentRetrospective::getPreviousChoicesOfTypeMode(const Instrument::Type instru
   return result;
 }
 
-std::optional<SegmentChoice *> SegmentRetrospective::getPreviousChoiceOfType(const Instrument::Type instrumentType) {
+std::optional<const SegmentChoice *> SegmentRetrospective::getPreviousChoiceOfType(const Instrument::Type instrumentType) {
   if (!previousSegment.has_value()) return std::nullopt;
   const auto choices = entityStore->readAllSegmentChoices(previousSegment.value()->id);
   for (const auto &choice: choices) {
@@ -109,16 +109,16 @@ std::optional<SegmentChoice *> SegmentRetrospective::getPreviousChoiceOfType(con
   return std::nullopt;
 }
 
-std::vector<Segment *> SegmentRetrospective::getSegments() {
+std::vector<const Segment *> SegmentRetrospective::getSegments() {
   return retroSegments;
 }
 
-std::set<SegmentChoice *> SegmentRetrospective::getChoices() {
+std::set<const SegmentChoice *> SegmentRetrospective::getChoices() {
   return entityStore->readAllSegmentChoices(previousSegmentIds);
 }
 
-std::set<SegmentChoice *> SegmentRetrospective::getPreviousChoicesForInstrument(const UUID &instrumentId) {
-  std::set<SegmentChoice *> result;
+std::set<const SegmentChoice *> SegmentRetrospective::getPreviousChoicesForInstrument(const UUID &instrumentId) {
+  std::set<const SegmentChoice *> result;
   if (!previousSegment.has_value()) return result;
   const auto choices = entityStore->readAllSegmentChoices(previousSegment.value()->id);
   for (const auto &choice: choices) {
@@ -129,9 +129,9 @@ std::set<SegmentChoice *> SegmentRetrospective::getPreviousChoicesForInstrument(
   return result;
 }
 
-std::set<SegmentChoiceArrangement *> SegmentRetrospective::getPreviousArrangementsForInstrument(UUID instrumentId) {
-  std::set<SegmentChoiceArrangement *> result;
-  const auto choices = getPreviousChoicesForInstrument(std::move(instrumentId));
+std::set<const SegmentChoiceArrangement *> SegmentRetrospective::getPreviousArrangementsForInstrument(UUID instrumentId) {
+  std::set<const SegmentChoiceArrangement *> result;
+  const auto choices = getPreviousChoicesForInstrument(instrumentId);
   const auto arrangements = entityStore->readAllSegmentChoiceArrangements(previousSegmentIds);
   for (const auto &choice: choices) {
     for (const auto &arrangement: arrangements) {
@@ -143,8 +143,8 @@ std::set<SegmentChoiceArrangement *> SegmentRetrospective::getPreviousArrangemen
   return result;
 }
 
-std::set<SegmentChoiceArrangementPick *> SegmentRetrospective::getPreviousPicksForInstrument(UUID instrumentId) {
-  std::set<SegmentChoiceArrangementPick *> result;
+std::set<const SegmentChoiceArrangementPick *> SegmentRetrospective::getPreviousPicksForInstrument(UUID instrumentId) {
+  std::set<const SegmentChoiceArrangementPick *> result;
   if (!previousSegment.has_value()) return result;
   const auto arrangements = getPreviousArrangementsForInstrument(std::move(instrumentId));
   const auto picks = entityStore->readAllSegmentChoiceArrangementPicks(
@@ -163,7 +163,7 @@ Instrument::Type SegmentRetrospective::getInstrumentType(const SegmentChoiceArra
   return getChoice(getArrangement(pick))->instrumentType;
 }
 
-std::optional<SegmentMeta *> SegmentRetrospective::getPreviousMeta(const std::string &key) {
+std::optional<const SegmentMeta *> SegmentRetrospective::getPreviousMeta(const std::string &key) {
   const auto metas = entityStore->readAllSegmentMetas(previousSegmentIds);
   for (const auto &meta: metas) {
     if (meta->key == key) {
@@ -173,7 +173,7 @@ std::optional<SegmentMeta *> SegmentRetrospective::getPreviousMeta(const std::st
   return std::nullopt;
 }
 
-SegmentChoiceArrangement * SegmentRetrospective::getArrangement(const SegmentChoiceArrangementPick *pick) {
+const SegmentChoiceArrangement * SegmentRetrospective::getArrangement(const SegmentChoiceArrangementPick *pick) {
   const auto arrangements = entityStore->readAllSegmentChoiceArrangements(pick->segmentId);
   for (const auto &arrangement: arrangements) {
     if (arrangement->id == pick->segmentChoiceArrangementId) {
@@ -183,7 +183,7 @@ SegmentChoiceArrangement * SegmentRetrospective::getArrangement(const SegmentCho
   throw FabricationException("Failed to get arrangement for SegmentChoiceArrangementPick[" + pick->id + "]");
 }
 
-SegmentChoice *SegmentRetrospective::getChoice(const SegmentChoiceArrangement *arrangement) {
+const SegmentChoice *SegmentRetrospective::getChoice(const SegmentChoiceArrangement *arrangement) {
   const auto choices = entityStore->readAllSegmentChoices(arrangement->segmentId);
   for (const auto &choice: choices) {
     if (choice->id == arrangement->segmentChoiceId) {
@@ -193,7 +193,7 @@ SegmentChoice *SegmentRetrospective::getChoice(const SegmentChoiceArrangement *a
   throw FabricationException("Failed to get arrangement for SegmentChoiceArrangement[" + arrangement->id + "]");
 }
 
-std::vector<SegmentChord *> SegmentRetrospective::getSegmentChords(const int segmentId) {
+std::vector<const SegmentChord *> SegmentRetrospective::getSegmentChords(const int segmentId) {
   if (segmentChords.find(segmentId) == segmentChords.end()) {
     auto chords = entityStore->readAllSegmentChords(segmentId);
     auto sortedChords = std::vector(chords.begin(), chords.end());

--- a/engine/src/fabricator/SegmentUtils.cpp
+++ b/engine/src/fabricator/SegmentUtils.cpp
@@ -6,7 +6,7 @@ using namespace XJ;
 
 
 std::optional<const SegmentChoice *>
-SegmentUtils::findFirstOfType(const std::set<SegmentChoice *> &segmentChoices, Program::Type type) {
+SegmentUtils::findFirstOfType(const std::set<const SegmentChoice *> &segmentChoices, Program::Type type) {
   const auto it = std::find_if(segmentChoices.begin(), segmentChoices.end(), [type](const SegmentChoice *choice) {
     return choice->programType == type;
   });
@@ -18,7 +18,7 @@ SegmentUtils::findFirstOfType(const std::set<SegmentChoice *> &segmentChoices, P
 
 
 std::optional<const SegmentChoice *>
-SegmentUtils::findFirstOfType(const std::set<SegmentChoice *> &segmentChoices, Instrument::Type type) {
+SegmentUtils::findFirstOfType(const std::set<const SegmentChoice *> &segmentChoices, Instrument::Type type) {
   const auto it = std::find_if(segmentChoices.begin(), segmentChoices.end(), [type](const SegmentChoice *choice) {
     return choice->instrumentType == type;
   });
@@ -29,7 +29,7 @@ SegmentUtils::findFirstOfType(const std::set<SegmentChoice *> &segmentChoices, I
 }
 
 
-std::string SegmentUtils::getIdentifier(Segment *segment) {
+std::string SegmentUtils::getIdentifier(const Segment *segment) {
   if (segment == nullptr) {
     return "N/A";
   }
@@ -37,7 +37,7 @@ std::string SegmentUtils::getIdentifier(Segment *segment) {
 }
 
 
-std::optional<Segment *> SegmentUtils::getLastCrafted(const std::vector<Segment *> &segments) {
+std::optional<const Segment *> SegmentUtils::getLastCrafted(const std::vector<const Segment *> &segments) {
   if (segments.empty()) {
     return std::nullopt;
   }
@@ -46,7 +46,7 @@ std::optional<Segment *> SegmentUtils::getLastCrafted(const std::vector<Segment 
 }
 
 
-std::optional<Segment *> SegmentUtils::getLast(const std::vector<Segment *> &segments) {
+std::optional<const Segment *> SegmentUtils::getLast(const std::vector<const Segment *> &segments) {
   if (segments.empty()) {
     return std::nullopt;
   }
@@ -56,8 +56,8 @@ std::optional<Segment *> SegmentUtils::getLast(const std::vector<Segment *> &seg
 }
 
 
-std::vector<Segment *> SegmentUtils::getCrafted(const std::vector<Segment *> &segments) {
-  std::vector<Segment *> result;
+std::vector<const Segment *> SegmentUtils::getCrafted(const std::vector<const Segment *> &segments) {
+  std::vector<const Segment *> result;
   std::copy_if(segments.begin(), segments.end(), std::back_inserter(result), [](const Segment *segment) {
     return segment->state == Segment::State::Crafted;
   });

--- a/engine/src/segment/SegmentChord.cpp
+++ b/engine/src/segment/SegmentChord.cpp
@@ -21,7 +21,7 @@ unsigned long long SegmentChord::hashCode() const {
 }
 
 
-std::set<std::string> SegmentChord::getNames(const std::set<SegmentChord *> &segmentChords) {
+std::set<std::string> SegmentChord::getNames(const std::set<const SegmentChord *> &segmentChords) {
   std::set<std::string> names;
   for (const auto &segmentChord: segmentChords) {
     names.insert(segmentChord->name);

--- a/engine/src/segment/SegmentEntityStore.cpp
+++ b/engine/src/segment/SegmentEntityStore.cpp
@@ -4,55 +4,54 @@
 #include "xjmusic/segment/SegmentEntityStore.h"
 #include "xjmusic/fabricator/FabricationException.h"
 #include "xjmusic/fabricator/SegmentUtils.h"
-#include "xjmusic/util/ValueUtils.h"
 
 using namespace XJ;
 
 
-#define SEGMENT_STORE_CORE_METHODS(ENTITY, ENTITIES, STORE)                                   \
-  ENTITY *SegmentEntityStore::put(const ENTITY &entity) {                                     \
-    if (STORE.find(entity.segmentId) == STORE.end()) {                                        \
-      STORE[entity.segmentId] = std::map<UUID, ENTITY>();                                     \
-    }                                                                                         \
-    STORE[entity.segmentId][entity.id] = entity;                                              \
-    return &STORE[entity.segmentId][entity.id];                                               \
-  }                                                                                           \
-  std::optional<ENTITY *> SegmentEntityStore::read##ENTITY(int segmentId, const UUID &id) {   \
-    if (STORE.find(segmentId) == STORE.end()) {                                               \
-      return std::nullopt;                                                                    \
-    }                                                                                         \
-    if (STORE[segmentId].find(id) == STORE[segmentId].end()) {                                \
-      return std::nullopt;                                                                    \
-    }                                                                                         \
-    return {&STORE[segmentId][id]};                                                           \
-  }                                                                                           \
-  std::set<ENTITY *> SegmentEntityStore::readAll##ENTITIES(int segmentId) {                   \
-    std::set<ENTITY *> result;                                                                \
-    if (STORE.find(segmentId) == STORE.end()) {                                               \
-      return result;                                                                          \
-    }                                                                                         \
-    for (auto &choice: STORE[segmentId]) {                                                    \
-      result.emplace(&choice.second);                                                         \
-    }                                                                                         \
-    return result;                                                                            \
-  }                                                                                           \
-  std::set<ENTITY *> SegmentEntityStore::readAll##ENTITIES(const std::set<int> &segmentIds) { \
-    std::set<ENTITY *> result;                                                                \
-    for (auto &segmentId: segmentIds) {                                                       \
-      if (STORE.find(segmentId) == STORE.end()) {                                             \
-        continue;                                                                             \
-      }                                                                                       \
-      for (auto &choice: STORE[segmentId]) {                                                  \
-        result.emplace(&choice.second);                                                       \
-      }                                                                                       \
-    }                                                                                         \
-    return result;                                                                            \
-  }                                                                                           \
-  void SegmentEntityStore::delete##ENTITY(int segmentId, const UUID &id) {                    \
-    if (STORE.find(segmentId) == STORE.end()) {                                               \
-      return;                                                                                 \
-    }                                                                                         \
-    STORE[segmentId].erase(id);                                                               \
+#define SEGMENT_STORE_CORE_METHODS(ENTITY, ENTITIES, STORE)                                         \
+  const ENTITY *SegmentEntityStore::put(const ENTITY &entity) {                                     \
+    if (STORE.find(entity.segmentId) == STORE.end()) {                                              \
+      STORE[entity.segmentId] = std::map<UUID, const ENTITY>();                                     \
+    }                                                                                               \
+    STORE[entity.segmentId].emplace(entity.id, entity);                                             \
+    return &STORE[entity.segmentId][entity.id];                                                     \
+  }                                                                                                 \
+  std::optional<const ENTITY *> SegmentEntityStore::read##ENTITY(int segmentId, const UUID &id) {   \
+    if (STORE.find(segmentId) == STORE.end()) {                                                     \
+      return std::nullopt;                                                                          \
+    }                                                                                               \
+    if (STORE[segmentId].find(id) == STORE[segmentId].end()) {                                      \
+      return std::nullopt;                                                                          \
+    }                                                                                               \
+    return {&STORE[segmentId][id]};                                                                 \
+  }                                                                                                 \
+  std::set<const ENTITY *> SegmentEntityStore::readAll##ENTITIES(int segmentId) {                   \
+    std::set<const ENTITY *> result;                                                                \
+    if (STORE.find(segmentId) == STORE.end()) {                                                     \
+      return result;                                                                                \
+    }                                                                                               \
+    for (auto &choice: STORE[segmentId]) {                                                          \
+      result.emplace(&choice.second);                                                               \
+    }                                                                                               \
+    return result;                                                                                  \
+  }                                                                                                 \
+  std::set<const ENTITY *> SegmentEntityStore::readAll##ENTITIES(const std::set<int> &segmentIds) { \
+    std::set<const ENTITY *> result;                                                                      \
+    for (auto &segmentId: segmentIds) {                                                             \
+      if (STORE.find(segmentId) == STORE.end()) {                                                   \
+        continue;                                                                                   \
+      }                                                                                             \
+      for (auto &choice: STORE[segmentId]) {                                                        \
+        result.emplace(&choice.second);                                                             \
+      }                                                                                             \
+    }                                                                                               \
+    return result;                                                                                  \
+  }                                                                                                 \
+  void SegmentEntityStore::delete##ENTITY(int segmentId, const UUID &id) {                          \
+    if (STORE.find(segmentId) == STORE.end()) {                                                     \
+      return;                                                                                       \
+    }                                                                                               \
+    STORE[segmentId].erase(id);                                                                     \
   }
 
 SEGMENT_STORE_CORE_METHODS(SegmentChoice, SegmentChoices, segmentChoices)
@@ -78,12 +77,12 @@ Chain *SegmentEntityStore::put(const Chain &chain) {
   return cc;
 }
 
-Segment *SegmentEntityStore::put(const Segment &segment) {
-  this->segments[segment.id] = segment;
+const Segment *SegmentEntityStore::put(const Segment &segment) {
+  this->segments.emplace(segment.id, segment);
   return &this->segments[segment.id];
 }
 
-std::optional<Segment *> SegmentEntityStore::readSegmentAtChainMicros(const long chainMicros) {
+std::optional<const Segment *> SegmentEntityStore::readSegmentAtChainMicros(const long chainMicros) {
   for (auto &[_, segment]: segments) {
     if (SegmentUtils::isSpanning(&segment, chainMicros, chainMicros)) {
       return {&segment};
@@ -96,13 +95,13 @@ std::optional<Chain *> SegmentEntityStore::readChain() {
   return chain.has_value() ? &chain.value() : nullptr;
 }
 
-std::optional<Segment *> SegmentEntityStore::readSegment(const int segmentId) {
+std::optional<const Segment *> SegmentEntityStore::readSegment(const int segmentId) {
   if (segments.find(segmentId) != segments.end()) return {&segments[segmentId]};
   return std::nullopt;
 }
 
-std::vector<Segment *> SegmentEntityStore::readAllSegments() {
-  std::vector<Segment *> result;
+std::vector<const Segment *> SegmentEntityStore::readAllSegments() {
+  std::vector<const Segment *> result;
   for (auto &[_, segment]: segments) {
     result.emplace_back(&segment);
   }
@@ -113,8 +112,8 @@ std::vector<Segment *> SegmentEntityStore::readAllSegments() {
 }
 
 
-std::vector<Segment *> SegmentEntityStore::readAllSegmentsInState(const Segment::State segmentState) {
-  std::vector<Segment *> result;
+std::vector<const Segment *> SegmentEntityStore::readAllSegmentsInState(const Segment::State segmentState) {
+  std::vector<const Segment *> result;
   for (auto &[_, segment]: segments) {
     if (segment.state == segmentState) {
       result.emplace_back(&segment);
@@ -126,8 +125,8 @@ std::vector<Segment *> SegmentEntityStore::readAllSegmentsInState(const Segment:
   return result;
 }
 
-std::vector<Segment> SegmentEntityStore::readSegmentsFromToOffset(const int fromOffset, const int toOffset) {
-  std::vector<Segment> result;
+std::vector<const Segment> SegmentEntityStore::readSegmentsFromToOffset(const int fromOffset, const int toOffset) {
+  std::vector<const Segment> result;
   for (auto &[_, segment]: segments) {
     if (segment.id >= fromOffset && segment.id <= toOffset) {
       result.emplace_back(segment);
@@ -137,8 +136,8 @@ std::vector<Segment> SegmentEntityStore::readSegmentsFromToOffset(const int from
 }
 
 
-std::set<SegmentEntity *> SegmentEntityStore::readAllSegmentEntities(const std::set<int> &segmentIds) {
-  std::set<SegmentEntity *> result;
+std::set<const SegmentEntity *> SegmentEntityStore::readAllSegmentEntities(const std::set<int> &segmentIds) {
+  std::set<const SegmentEntity *> result;
   for (auto &segmentId: segmentIds) {
     for (auto &choice: readAllSegmentChoices(segmentId)) {
       result.emplace(choice);
@@ -196,7 +195,8 @@ std::optional<Segment> SegmentEntityStore::readSegmentLast() {
 }
 
 
-std::optional<SegmentChoice *> SegmentEntityStore::readChoice(const int segmentId, const Program::Type programType) {
+std::optional<const SegmentChoice *>
+SegmentEntityStore::readChoice(const int segmentId, const Program::Type programType) {
   if (segmentChoices.find(segmentId) == segmentChoices.end()) {
     return std::nullopt;
   }
@@ -210,7 +210,7 @@ std::optional<SegmentChoice *> SegmentEntityStore::readChoice(const int segmentI
 
 
 std::string SegmentEntityStore::readChoiceHash(const Segment &segment) {
-  const std::set<SegmentEntity *> entities = readAllSegmentEntities({segment.id});
+  const std::set<const SegmentEntity *> entities = readAllSegmentEntities({segment.id});
   std::vector<std::string> ids;
 
   for (const auto &entity: entities) {
@@ -221,7 +221,8 @@ std::string SegmentEntityStore::readChoiceHash(const Segment &segment) {
   return StringUtils::join(ids, "_");
 }
 
-std::set<const SegmentChoiceArrangementPick *> SegmentEntityStore::readAllSegmentChoiceArrangementPicks(const std::vector<const Segment *> &segments) {
+std::set<const SegmentChoiceArrangementPick *>
+SegmentEntityStore::readAllSegmentChoiceArrangementPicks(const std::vector<const Segment *> &segments) {
   std::set<const SegmentChoiceArrangementPick *> picks;
   for (auto &segment: segments) {
     for (auto &pick: readAllSegmentChoiceArrangementPicks(segment->id)) {
@@ -242,13 +243,13 @@ bool SegmentEntityStore::empty() const {
 }
 
 
-Segment *SegmentEntityStore::updateSegment(Segment &segment) {
+const Segment *SegmentEntityStore::updateSegment(Segment &segment) {
   // validate and cache to-state
   validate(segment);
   const Segment::State toState = segment.state;
 
   // fetch existing segment; further logic is based on its current state
-  const std::optional<Segment *> existingOpt = readSegment(segment.id);
+  const std::optional<const Segment *> existingOpt = readSegment(segment.id);
   if (existingOpt.has_value()) {
     const Segment *existing = existingOpt.value();
 
@@ -295,28 +296,28 @@ void SegmentEntityStore::protectSegmentStateTransition(const Segment::State from
   switch (fromState) {
     case Segment::State::Planned:
       onlyAllowSegmentStateTransitions(toState, {
-                                                    Segment::State::Planned,
-                                                    Segment::State::Crafting,
-                                                });
+          Segment::State::Planned,
+          Segment::State::Crafting,
+      });
       break;
     case Segment::State::Crafting:
       onlyAllowSegmentStateTransitions(toState, {
-                                                    Segment::State::Crafting,
-                                                    Segment::State::Crafted,
-                                                    Segment::State::Failed,
-                                                    Segment::State::Planned,
-                                                });
+          Segment::State::Crafting,
+          Segment::State::Crafted,
+          Segment::State::Failed,
+          Segment::State::Planned,
+      });
       break;
     case Segment::State::Crafted:
       onlyAllowSegmentStateTransitions(toState, {
-                                                    Segment::State::Crafted,
-                                                    Segment::State::Crafting,
-                                                });
+          Segment::State::Crafted,
+          Segment::State::Crafting,
+      });
       break;
     case Segment::State::Failed:
       onlyAllowSegmentStateTransitions(toState, {
-                                                    Segment::State::Failed,
-                                                });
+          Segment::State::Failed,
+      });
       break;
     default:
       onlyAllowSegmentStateTransitions(toState, {Segment::State::Planned});

--- a/engine/src/segment/SegmentEntityStore.cpp
+++ b/engine/src/segment/SegmentEntityStore.cpp
@@ -71,15 +71,19 @@ SEGMENT_STORE_CORE_METHODS(SegmentMessage, SegmentMessages, segmentMessages)
 SEGMENT_STORE_CORE_METHODS(SegmentMeta, SegmentMetas, segmentMetas)
 
 
-Chain *SegmentEntityStore::put(const Chain &chain) {
-  const auto cc = new Chain(chain);
+Chain *SegmentEntityStore::put(const Chain &c) {
+  const auto cc = new Chain(c);
   this->chain = *cc;
   return cc;
 }
 
 const Segment *SegmentEntityStore::put(const Segment &segment) {
-  this->segments.emplace(segment.id, segment);
-  return &this->segments[segment.id];
+  auto existing = this->segments.find(segment.id);
+  if (existing != this->segments.end()) {
+    this->segments.erase(segment.id);
+  }
+  this->segments.emplace(segment.id, segment); // TODO this seems terrible -- think about replacing keys in a map of const
+  return &this->segments.at(segment.id);
 }
 
 std::optional<const Segment *> SegmentEntityStore::readSegmentAtChainMicros(const long chainMicros) {
@@ -270,7 +274,8 @@ const Segment *SegmentEntityStore::updateSegment(Segment &segment) {
   segment.updatedAt = EntityUtils::currentTimeMillis();
 
   // save segment
-  return put(segment);
+  auto updated = put(segment);
+  return updated;
 }
 
 

--- a/engine/src/segment/SegmentMeme.cpp
+++ b/engine/src/segment/SegmentMeme.cpp
@@ -19,7 +19,7 @@ unsigned long long SegmentMeme::hashCode() const {
 }
 
 
-std::set<std::string> SegmentMeme::getNames(const std::set<SegmentMeme *> &segmentMemes) {
+std::set<std::string> SegmentMeme::getNames(const std::set<const SegmentMeme *> &segmentMemes) {
   std::set<std::string> names;
   for (const auto &segmentMeme: segmentMemes) {
     names.insert(segmentMeme->name);

--- a/engine/src/util/ValueUtils.cpp
+++ b/engine/src/util/ValueUtils.cpp
@@ -129,8 +129,8 @@ int ValueUtils::multipleFloor(const int factor, const float value) {
 }
 
 
-float ValueUtils::interpolate(const float floor, const float ceiling, const float position, const float multiplier) {
-  return floor + (ceiling - floor) * position * multiplier;
+float ValueUtils::interpolate(const float floor, const float ceiling, const float position) {
+  return floor + (ceiling - floor) * position;
 }
 
 

--- a/engine/src/util/ValueUtils.cpp
+++ b/engine/src/util/ValueUtils.cpp
@@ -21,6 +21,7 @@ long ValueUtils::MILLIS_PER_SECOND = 1000;
 long ValueUtils::MICROS_PER_MILLI = 1000;
 long ValueUtils::NANOS_PER_MICRO = 1000;
 long ValueUtils::MICROS_PER_SECOND = MICROS_PER_MILLI * MILLIS_PER_SECOND;
+float ValueUtils::MICROS_PER_SECOND_FLOAT = static_cast<float>(MICROS_PER_SECOND);
 long ValueUtils::NANOS_PER_SECOND = NANOS_PER_MICRO * MICROS_PER_SECOND;
 long ValueUtils::SECONDS_PER_MINUTE = 60;
 long ValueUtils::MICROS_PER_MINUTE = SECONDS_PER_MINUTE * MICROS_PER_SECOND;
@@ -143,9 +144,9 @@ std::optional<UUID> ValueUtils::getKeyOfHighestValue(const std::map<UUID, int> &
   if (map.empty()) return std::nullopt;
 
   const auto max_it = std::max_element(map.begin(), map.end(),
-                                 [](const auto &a, const auto &b) {
-                                   return a.second < b.second;
-                                 });
+                                       [](const auto &a, const auto &b) {
+                                         return a.second < b.second;
+                                       });
 
   return max_it->first;
 }

--- a/engine/src/work/CraftWork.cpp
+++ b/engine/src/work/CraftWork.cpp
@@ -61,14 +61,14 @@ std::vector<const Segment *> CraftWork::getSegmentsIfReady(const unsigned long l
   if (currentSegments.empty()) {
     return {};
   }
-  auto previousSegment = store->readSegment(currentSegments.at(0).id - 1);
-  auto nextSegment = store->readSegment(currentSegments.at(currentSegments.size() - 1).id + 1);
+  auto previousSegment = store->readSegment(currentSegments.at(0)->id - 1);
+  auto nextSegment = store->readSegment(currentSegments.at(currentSegments.size() - 1)->id + 1);
   std::vector<const Segment *> segments;
   if (previousSegment.has_value() && Segment::State::Crafted == previousSegment.value()->state)
     segments.emplace_back(previousSegment.value());
   for (auto segment: currentSegments)
-    if (Segment::State::Crafted == segment.state)
-      segments.emplace_back(&segment);
+    if (Segment::State::Crafted == segment->state)
+      segments.emplace_back(segment);
   if (nextSegment.has_value() && Segment::State::Crafted == nextSegment.value()->state)
     segments.emplace_back(nextSegment.value());
   return segments;
@@ -131,7 +131,7 @@ bool CraftWork::isMuted(const SegmentChoiceArrangementPick *pick) const {
   }
 }
 
-bool CraftWork::isFinished() {
+bool CraftWork::isFinished() const {
   return !running;
 }
 
@@ -235,11 +235,11 @@ void CraftWork::doFabricationDefault(
     const auto existing = store->readSegmentLast();
     if (!existing.has_value()) {
       segment = buildSegmentInitial();
-    } else if (!existing.value().durationMicros.has_value()) {
+    } else if (!existing.value()->durationMicros.has_value()) {
       spdlog::debug("Last segment in chain has no duration, cannot fabricate next segment");
       return;
     } else {
-      segment = buildSegmentFollowing(&existing.value());
+      segment = buildSegmentFollowing(existing.value());
     }
     doFabricationWork(store->put(segment), std::nullopt, overrideMacroProgram, overrideMemes);
 
@@ -410,11 +410,11 @@ const Chain *CraftWork::createChainForTemplate(const Template *tmpl) const {
   return store->put(entity);
 }
 
-std::set<const SegmentChoice *> CraftWork::getChoices(const Segment *segment) {
+std::set<const SegmentChoice *> CraftWork::getChoices(const Segment *segment) const {
   return store->readAllSegmentChoices(segment->id);
 }
 
-std::set<const SegmentChoiceArrangement *> CraftWork::getArrangements(const SegmentChoice *choice) {
+std::set<const SegmentChoiceArrangement *> CraftWork::getArrangements(const SegmentChoice *choice) const {
   std::set<const SegmentChoiceArrangement *> results;
   for (auto arrangement : store->readAllSegmentChoiceArrangements( choice->segmentId))
     if (arrangement->segmentChoiceId == choice->id)
@@ -422,7 +422,7 @@ std::set<const SegmentChoiceArrangement *> CraftWork::getArrangements(const Segm
   return results;
 }
 
-std::set<const SegmentChoiceArrangementPick *> CraftWork::getPicks(const SegmentChoiceArrangement *arrangement) {
+std::set<const SegmentChoiceArrangementPick *> CraftWork::getPicks(const SegmentChoiceArrangement *arrangement) const {
   std::set<const SegmentChoiceArrangementPick *> results;
   for (auto pick : store->readAllSegmentChoiceArrangementPicks( arrangement->segmentId))
     if (pick->segmentChoiceArrangementId == arrangement->id)

--- a/engine/src/work/CraftWork.cpp
+++ b/engine/src/work/CraftWork.cpp
@@ -342,7 +342,7 @@ void CraftWork::doFabricationWork(
   Fabricator *fabricator = fabricatorFactory->fabricate(content, inputSegment->id, overrideSegmentType);
 
   spdlog::debug("[segId={}] will do craft work", inputSegment->id);
-  updateSegmentState(fabricator, inputSegment, Segment::State::Planned, Segment::State::Crafting);
+  const Segment * updatedSegment = updateSegmentState(fabricator, inputSegment, Segment::State::Planned, Segment::State::Crafting);
   craftFactory->macroMain(fabricator, overrideMacroProgram, overrideMemes).doWork();
 
   craftFactory->beat(fabricator).doWork();
@@ -352,7 +352,7 @@ void CraftWork::doFabricationWork(
 
   spdlog::debug("Fabricated Segment[{}]", inputSegment->id);
 
-  updateSegmentState(fabricator, inputSegment, Segment::State::Crafting, Segment::State::Crafted);
+  updateSegmentState(fabricator, updatedSegment, Segment::State::Crafting, Segment::State::Crafted);
 }
 
 void CraftWork::doSegmentCleanup(const long shippedToChainMicros) const {
@@ -395,7 +395,7 @@ void CraftWork::didFailWhile(std::string msgWhile, const std::exception &e) {
 const Segment *
 CraftWork::updateSegmentState(Fabricator *fabricator, const Segment *inputSegment, const Segment::State fromState, const Segment::State toState) {
   if (fromState != inputSegment->state)
-    throw new std::runtime_error("Segment[" + std::to_string(inputSegment->id) + "] " + Segment::toString(toState) + " requires Segment must be in " + Segment::toString(fromState) + " state.");
+    throw std::runtime_error("Segment[" + std::to_string(inputSegment->id) + "] " + Segment::toString(toState) + " requires Segment must be in " + Segment::toString(fromState) + " state.");
   Segment updateSegment = *inputSegment;
   updateSegment.state = toState;
   auto updatedSegment = fabricator->updateSegment(updateSegment);

--- a/engine/test/_mock/MockFabricator.h
+++ b/engine/test/_mock/MockFabricator.h
@@ -25,7 +25,7 @@ namespace XJ {
 
     MOCK_METHOD(SegmentRetrospective *, getRetrospective, (), (override));
     MOCK_METHOD(ContentEntityStore *, getSourceMaterial, (), (override));
-    MOCK_METHOD(Segment *, getSegment, (), (override));
+    MOCK_METHOD(const Segment *, getSegment, (), (override));
     MOCK_METHOD(InstrumentConfig, getInstrumentConfig, (const Instrument *instrument), (override));
     MOCK_METHOD(MemeIsometry, getMemeIsometryOfSegment, (), (override));
   };

--- a/engine/test/_mock/MockSegmentRetrospective.h
+++ b/engine/test/_mock/MockSegmentRetrospective.h
@@ -18,22 +18,22 @@ namespace XJ {
       auto segment = Segment();
     }
 
-    MOCK_METHOD(std::set<SegmentChoiceArrangementPick*>, getPreviousPicksForInstrument, (UUID instrumentId));
-    MOCK_METHOD(SegmentChoiceArrangement *, getArrangement, (const SegmentChoiceArrangementPick * pick));
-    MOCK_METHOD(std::set<SegmentChoice *>, getChoices, ());
-    MOCK_METHOD(SegmentChoice, getChoice, (const SegmentChoiceArrangement& arrangement));
+    MOCK_METHOD(std::set<const SegmentChoiceArrangementPick*>, getPreviousPicksForInstrument, (UUID instrumentId));
+    MOCK_METHOD(const SegmentChoiceArrangement *, getArrangement, (const SegmentChoiceArrangementPick * pick));
+    MOCK_METHOD(std::set<const SegmentChoice *>, getChoices, ());
+    MOCK_METHOD(const SegmentChoice *, getChoice, (const SegmentChoiceArrangement& arrangement));
     MOCK_METHOD(Instrument::Type, getInstrumentType, (SegmentChoiceArrangementPick pick));
-    MOCK_METHOD(std::optional<SegmentMeta*>, getPreviousMeta, (const std::string& key));
-    MOCK_METHOD(std::set<SegmentChoice*>, getPreviousChoicesForInstrument, (const UUID& instrumentId));
-    MOCK_METHOD(std::set<SegmentChoiceArrangement*>, getPreviousArrangementsForInstrument, (UUID instrumentId));
-    MOCK_METHOD(std::optional<SegmentChoice*>, getPreviousChoiceOfType, (const Segment &segment, Program::Type type));
-    MOCK_METHOD(std::optional<SegmentChoice*>, getPreviousChoiceOfType, (Program::Type type));
-    MOCK_METHOD(std::set<SegmentChoice*>, getPreviousChoicesOfMode, (Instrument::Mode instrumentMode));
-    MOCK_METHOD(std::set<SegmentChoice*>, getPreviousChoicesOfTypeMode, (Instrument::Type instrumentType, Instrument::Mode instrumentModes));
-    MOCK_METHOD(std::optional<SegmentChoice*>, getPreviousChoiceOfType, (Instrument::Type instrumentType));
-    MOCK_METHOD(std::optional<Segment*>, getPreviousSegment, ());
-    MOCK_METHOD(std::vector<Segment*>, getSegments, ());
-    MOCK_METHOD(std::vector<SegmentChord*>, getSegmentChords, (int segmentId));
+    MOCK_METHOD(std::optional<const SegmentMeta*>, getPreviousMeta, (const std::string& key));
+    MOCK_METHOD(std::set<const SegmentChoice*>, getPreviousChoicesForInstrument, (const UUID& instrumentId));
+    MOCK_METHOD(std::set<const SegmentChoiceArrangement*>, getPreviousArrangementsForInstrument, (UUID instrumentId));
+    MOCK_METHOD(std::optional<const SegmentChoice*>, getPreviousChoiceOfType, (const Segment &segment, Program::Type type));
+    MOCK_METHOD(std::optional<const SegmentChoice*>, getPreviousChoiceOfType, (Program::Type type));
+    MOCK_METHOD(std::set<const SegmentChoice*>, getPreviousChoicesOfMode, (Instrument::Mode instrumentMode));
+    MOCK_METHOD(std::set<const SegmentChoice*>, getPreviousChoicesOfTypeMode, (Instrument::Type instrumentType, Instrument::Mode instrumentModes));
+    MOCK_METHOD(std::optional<const SegmentChoice*>, getPreviousChoiceOfType, (Instrument::Type instrumentType));
+    MOCK_METHOD(std::optional<const Segment*>, getPreviousSegment, ());
+    MOCK_METHOD(std::vector<const Segment*>, getSegments, ());
+    MOCK_METHOD(std::vector<const SegmentChord*>, getSegmentChords, (int segmentId));
   };
 
 } // namespace XJ

--- a/engine/test/craft/ArrangementTest.cpp
+++ b/engine/test/craft/ArrangementTest.cpp
@@ -50,7 +50,7 @@ protected:
   std::map<Instrument::Type, std::vector<ProgramSequencePatternEvent>> detailProgramSequencePatternEvents;
   std::vector<StickyBun> stickyBuns;
   Chain *chain = nullptr;
-  Segment *segment = nullptr;
+  const Segment *segment = nullptr;
   std::map<Instrument::Type, const SegmentChoice *> segmentChoices;
   Program mainProgram1;
 
@@ -287,9 +287,9 @@ protected:
     auto objs = data[StringUtils::toLowerCase(Instrument::toString(type))];
     if (!objs) return;
 
-    std::vector<SegmentChoiceArrangementPick *> actualPicks;
+    std::vector<const SegmentChoiceArrangementPick *> actualPicks;
     for (const auto &pick: fabricator->getPicks())
-      actualPicks.push_back(pick);
+      actualPicks.emplace_back(pick);
     std::sort(actualPicks.begin(), actualPicks.end(), [](const auto *a, const auto *b) {
       return a->startAtSegmentMicros < b->startAtSegmentMicros;
     });

--- a/engine/test/craft/CraftTest.cpp
+++ b/engine/test/craft/CraftTest.cpp
@@ -30,24 +30,28 @@ protected:
   ContentEntityStore *sourceMaterial = nullptr;
   MockSegmentRetrospective *mockSegmentRetrospective = nullptr;
   Craft *subject = nullptr;
-  Segment *segment0 = nullptr;
+  const Segment *segment0 = nullptr;
   Program *program1 = nullptr;
-  TemplateConfig * templateConfig = nullptr;
+  TemplateConfig *templateConfig = nullptr;
 
   void SetUp() override {
     sourceMaterial = new ContentEntityStore();
     segmentEntityStore = new SegmentEntityStore();
     const Project *project1 = sourceMaterial->put(ContentFixtures::buildProject("fish"));
     const Library *library1 = sourceMaterial->put(ContentFixtures::buildLibrary(project1, "sea"));
-    program1 = sourceMaterial->put(ContentFixtures::buildProgram(library1, Program::Type::Detail, Program::State::Published, "swimming",
-                                                                 "C", 120.0f));
-    const Template *template1 = sourceMaterial->put(ContentFixtures::buildTemplate(project1, "Test Template 1", "test1"));
+    program1 = sourceMaterial->put(
+        ContentFixtures::buildProgram(library1, Program::Type::Detail, Program::State::Published, "swimming",
+                                      "C", 120.0f));
+    const Template *template1 = sourceMaterial->put(
+        ContentFixtures::buildTemplate(project1, "Test Template 1", "test1"));
     // Chain "Test Print #1" is fabricating segments
-    const Chain *chain1 = segmentEntityStore->put(SegmentFixtures::buildChain("Test Print #1", Chain::Type::Production, Chain::State::Fabricate,
-                                                                              template1));
+    const Chain *chain1 = segmentEntityStore->put(
+        SegmentFixtures::buildChain("Test Print #1", Chain::Type::Production, Chain::State::Fabricate,
+                                    template1));
 
-    segment0 = segmentEntityStore->put(SegmentFixtures::buildSegment(chain1, Segment::Type::Initial, 2, 128, Segment::State::Crafted, "D major",
-                                                                     64, 0.73f, 120.0f, "chains-1-segments-9f7s89d8a7892", true));
+    segment0 = segmentEntityStore->put(
+        SegmentFixtures::buildSegment(chain1, Segment::Type::Initial, 2, 128, Segment::State::Crafted, "D major",
+                                      64, 0.73f, 120.0f, "chains-1-segments-9f7s89d8a7892", true));
 
     templateConfig = new TemplateConfig(template1);
     mockSegmentRetrospective = new MockSegmentRetrospective(segmentEntityStore, 2);
@@ -110,6 +114,7 @@ TEST_F(CraftTest, PrecomputeDeltas) {
     return choice->programType == Program::Type::Detail;
   };
   std::vector<std::string> detailLayerOrder;
+  detailLayerOrder.reserve(templateConfig->detailLayerOrder.size());
   for (const auto &type: templateConfig->detailLayerOrder) {
     detailLayerOrder.push_back(Instrument::toString(type));
   }
@@ -232,7 +237,7 @@ TEST_F(CraftTest, ChooseFreshInstrumentAudio) {
 
   // Call the method under test
   const auto result = subject->chooseFreshInstrumentAudio({Instrument::Type::Percussion}, {Instrument::Mode::Event},
-                                                    {instrument1audio->instrumentId}, {"PRIMARY"});
+                                                          {instrument1audio->instrumentId}, {"PRIMARY"});
 
   // Check the result
   EXPECT_TRUE(result.has_value());
@@ -303,7 +308,8 @@ TEST_F(CraftTest, SelectGeneralAudioIntensityLayers_ThreeLayers) {
   EXPECT_CALL(*mockFabricator, getSourceMaterial()).WillRepeatedly(Return(sourceMaterial));
   EXPECT_CALL(*mockFabricator, getRetrospective()).WillRepeatedly(Return(mockSegmentRetrospective));
   EXPECT_CALL(*mockFabricator, getSegment()).WillRepeatedly(Return(segment0));
-  EXPECT_CALL(*mockSegmentRetrospective, getPreviousPicksForInstrument(instrument1->id)).WillOnce(Return(std::set<SegmentChoiceArrangementPick*>{}));
+  EXPECT_CALL(*mockSegmentRetrospective, getPreviousPicksForInstrument(instrument1->id)).WillOnce(
+      Return(std::set<const SegmentChoiceArrangementPick *>{}));
 
   // Call the method under test
   auto result = subject->selectGeneralAudioIntensityLayers(instrument1);
@@ -366,7 +372,8 @@ TEST_F(CraftTest, SelectGeneralAudioIntensityLayers_ContinueSegment) {
   EXPECT_CALL(*mockFabricator, getSourceMaterial()).WillRepeatedly(Return(sourceMaterial));
   EXPECT_CALL(*mockFabricator, getRetrospective()).WillRepeatedly(Return(mockSegmentRetrospective));
   EXPECT_CALL(*mockFabricator, getSegment()).WillRepeatedly(Return(segment0));
-  EXPECT_CALL(*mockSegmentRetrospective, getPreviousPicksForInstrument(instrument1->id)).WillOnce(Return(std::set{&pick1, &pick2, &pick3}));
+  EXPECT_CALL(*mockSegmentRetrospective, getPreviousPicksForInstrument(instrument1->id)).WillOnce(
+      Return(std::set<const SegmentChoiceArrangementPick *>({&pick1, &pick2, &pick3})));
   EXPECT_CALL(*mockFabricator, getInstrumentConfig(_)).WillOnce(Return(instrumentConfig));
 
   // Call the method under test

--- a/engine/test/craft/background/CraftBackgroundContinueTest.cpp
+++ b/engine/test/craft/background/CraftBackgroundContinueTest.cpp
@@ -27,7 +27,7 @@ protected:
   SegmentEntityStore *store = nullptr;
   ContentFixtures *fake = nullptr;
   Chain *chain1 = nullptr;
-  Segment *segment4 = nullptr;
+  const Segment *segment4 = nullptr;
 
   void SetUp() override {
     craftFactory = new CraftFactory();

--- a/engine/test/craft/background/CraftBackgroundInitialTest.cpp
+++ b/engine/test/craft/background/CraftBackgroundInitialTest.cpp
@@ -6,15 +6,11 @@
 
 #include "../../_helper/ContentFixtures.h"
 #include "../../_helper/SegmentFixtures.h"
-#include "../../_helper/YamlTest.h"
 
 #include "xjmusic/craft/Craft.h"
 #include "xjmusic/craft/CraftFactory.h"
-#include "xjmusic/fabricator/ChainUtils.h"
 #include "xjmusic/fabricator/FabricatorFactory.h"
-#include "xjmusic/fabricator/SegmentUtils.h"
 #include "xjmusic/util/CsvUtils.h"
-#include "xjmusic/util/ValueUtils.h"
 
 // NOLINTNEXTLINE
 using ::testing::_;
@@ -29,7 +25,7 @@ protected:
   FabricatorFactory *fabricatorFactory = nullptr;
   ContentEntityStore *sourceMaterial = nullptr;
   SegmentEntityStore *store = nullptr;
-  Segment *segment6 = nullptr;
+  const Segment *segment6 = nullptr;
 
   void SetUp() override {
     craftFactory = new CraftFactory();

--- a/engine/test/craft/background/CraftBackgroundNextMacroTest.cpp
+++ b/engine/test/craft/background/CraftBackgroundNextMacroTest.cpp
@@ -31,7 +31,7 @@ protected:
   SegmentEntityStore *store = nullptr;
   ContentEntityStore *sourceMaterial = nullptr;
   Chain *chain1 = nullptr;
-  Segment *segment4 = nullptr;
+  const Segment *segment4 = nullptr;
 
   void SetUp() override {
     craftFactory = new CraftFactory();

--- a/engine/test/craft/background/CraftBackgroundNextMainTest.cpp
+++ b/engine/test/craft/background/CraftBackgroundNextMainTest.cpp
@@ -31,7 +31,7 @@ protected:
   SegmentEntityStore *store = nullptr;
   ContentFixtures *fake = nullptr;
   Chain *chain1 = nullptr;
-  Segment *segment4 = nullptr;
+  const Segment *segment4 = nullptr;
 
   void SetUp() override {
     craftFactory = new CraftFactory();

--- a/engine/test/craft/background/CraftBackgroundProgramVoiceContinueTest.cpp
+++ b/engine/test/craft/background/CraftBackgroundProgramVoiceContinueTest.cpp
@@ -31,7 +31,7 @@ protected:
   SegmentEntityStore *store = nullptr;
   ContentFixtures *fake = nullptr;
   Chain *chain1 = nullptr;
-  Segment *segment4 = nullptr;
+  const Segment *segment4 = nullptr;
   InstrumentAudio *audioKick = nullptr;
   InstrumentAudio *audioSnare = nullptr;
 

--- a/engine/test/craft/background/CraftBackgroundProgramVoiceInitialTest.cpp
+++ b/engine/test/craft/background/CraftBackgroundProgramVoiceInitialTest.cpp
@@ -10,11 +10,8 @@
 
 #include "xjmusic/craft/Craft.h"
 #include "xjmusic/craft/CraftFactory.h"
-#include "xjmusic/fabricator/ChainUtils.h"
 #include "xjmusic/fabricator/FabricatorFactory.h"
-#include "xjmusic/fabricator/SegmentUtils.h"
 #include "xjmusic/util/CsvUtils.h"
-#include "xjmusic/util/ValueUtils.h"
 
 // NOLINTNEXTLINE
 using ::testing::_;
@@ -31,7 +28,7 @@ protected:
   SegmentEntityStore *store = nullptr;
   ContentFixtures *fake = nullptr;
   Chain *chain2 = nullptr;
-  Segment *segment0 = nullptr;
+  const Segment *segment0 = nullptr;
 
   void SetUp() override {
     craftFactory = new CraftFactory();

--- a/engine/test/craft/background/CraftBackgroundProgramVoiceNextMacroTest.cpp
+++ b/engine/test/craft/background/CraftBackgroundProgramVoiceNextMacroTest.cpp
@@ -31,7 +31,7 @@ protected:
   SegmentEntityStore *store = nullptr;
   ContentFixtures *fake = nullptr;
   Chain *chain1 = nullptr;
-  Segment *segment4 = nullptr;
+  const Segment *segment4 = nullptr;
 
   void SetUp() override {
     craftFactory = new CraftFactory();

--- a/engine/test/craft/background/CraftBackgroundProgramVoiceNextMainTest.cpp
+++ b/engine/test/craft/background/CraftBackgroundProgramVoiceNextMainTest.cpp
@@ -31,7 +31,7 @@ protected:
   SegmentEntityStore *store = nullptr;
   ContentEntityStore *sourceMaterial = nullptr;
   Chain *chain1 = nullptr;
-  Segment *segment4 = nullptr;
+  const Segment *segment4 = nullptr;
   InstrumentAudio *audioKick = nullptr;
   InstrumentAudio *audioSnare = nullptr;
 

--- a/engine/test/craft/background/CraftBackground_LayeredVoicesTest.cpp
+++ b/engine/test/craft/background/CraftBackground_LayeredVoicesTest.cpp
@@ -31,7 +31,7 @@ protected:
   FabricatorFactory *fabricatorFactory = nullptr;
   ContentEntityStore *sourceMaterial = nullptr;
   ContentFixtures *fake = nullptr;
-  Segment *segment4 = nullptr;
+  const Segment *segment4 = nullptr;
 
   void SetUp() override {
     craftFactory = new CraftFactory();

--- a/engine/test/craft/beat/CraftBeatContinueTest.cpp
+++ b/engine/test/craft/beat/CraftBeatContinueTest.cpp
@@ -31,7 +31,7 @@ protected:
   SegmentEntityStore *store = nullptr;
   ContentFixtures *fake = nullptr;
   Chain *chain1 = nullptr;
-  Segment *segment4 = nullptr;
+  const Segment *segment4 = nullptr;
 
   void SetUp() override {
     craftFactory = new CraftFactory();

--- a/engine/test/craft/beat/CraftBeatInitialTest.cpp
+++ b/engine/test/craft/beat/CraftBeatInitialTest.cpp
@@ -6,14 +6,11 @@
 
 #include "../../_helper/ContentFixtures.h"
 #include "../../_helper/SegmentFixtures.h"
-#include "../../_helper/YamlTest.h"
 
 #include "xjmusic/craft/Craft.h"
 #include "xjmusic/craft/CraftFactory.h"
-#include "xjmusic/fabricator/ChainUtils.h"
 #include "xjmusic/fabricator/FabricatorFactory.h"
 #include "xjmusic/fabricator/SegmentUtils.h"
-#include "xjmusic/util/ValueUtils.h"
 
 // NOLINTNEXTLINE
 using ::testing::_;
@@ -28,7 +25,7 @@ protected:
   FabricatorFactory *fabricatorFactory = nullptr;
   ContentEntityStore *sourceMaterial = nullptr;
   SegmentEntityStore *store = nullptr;
-  Segment *segment6 = nullptr;
+  const Segment *segment6 = nullptr;
 
   void SetUp() override {
     craftFactory = new CraftFactory();

--- a/engine/test/craft/beat/CraftBeatNextMacroTest.cpp
+++ b/engine/test/craft/beat/CraftBeatNextMacroTest.cpp
@@ -31,7 +31,7 @@ protected:
   SegmentEntityStore *store = nullptr;
   ContentEntityStore *sourceMaterial = nullptr;
   Chain *chain1 = nullptr;
-  Segment *segment4 = nullptr;
+  const Segment *segment4 = nullptr;
 
   void SetUp() override {
     craftFactory = new CraftFactory();

--- a/engine/test/craft/beat/CraftBeatNextMainTest.cpp
+++ b/engine/test/craft/beat/CraftBeatNextMainTest.cpp
@@ -31,7 +31,7 @@ protected:
   SegmentEntityStore *store = nullptr;
   ContentFixtures *fake = nullptr;
   Chain *chain1 = nullptr;
-  Segment *segment4 = nullptr;
+  const Segment *segment4 = nullptr;
 
   void SetUp() override {
     craftFactory = new CraftFactory();

--- a/engine/test/craft/beat/CraftBeatProgramVoiceContinueTest.cpp
+++ b/engine/test/craft/beat/CraftBeatProgramVoiceContinueTest.cpp
@@ -6,15 +6,11 @@
 
 #include "../../_helper/ContentFixtures.h"
 #include "../../_helper/SegmentFixtures.h"
-#include "../../_helper/YamlTest.h"
 
 #include "xjmusic/craft/Craft.h"
 #include "xjmusic/craft/CraftFactory.h"
-#include "xjmusic/fabricator/ChainUtils.h"
 #include "xjmusic/fabricator/FabricatorFactory.h"
-#include "xjmusic/fabricator/SegmentUtils.h"
 #include "xjmusic/util/CsvUtils.h"
-#include "xjmusic/util/ValueUtils.h"
 
 // NOLINTNEXTLINE
 using ::testing::_;
@@ -31,7 +27,7 @@ protected:
   SegmentEntityStore *store = nullptr;
   ContentFixtures *fake = nullptr;
   Chain *chain1 = nullptr;
-  Segment *segment4 = nullptr;
+  const Segment *segment4 = nullptr;
   InstrumentAudio *audioKick = nullptr;
   InstrumentAudio *audioSnare = nullptr;
 

--- a/engine/test/craft/beat/CraftBeatProgramVoiceInitialTest.cpp
+++ b/engine/test/craft/beat/CraftBeatProgramVoiceInitialTest.cpp
@@ -31,7 +31,7 @@ protected:
   SegmentEntityStore *store = nullptr;
   ContentFixtures *fake = nullptr;
   Chain *chain2 = nullptr;
-  Segment *segment0 = nullptr;
+  const Segment *segment0 = nullptr;
 
   void SetUp() override {
     craftFactory = new CraftFactory();

--- a/engine/test/craft/beat/CraftBeatProgramVoiceNextMacroTest.cpp
+++ b/engine/test/craft/beat/CraftBeatProgramVoiceNextMacroTest.cpp
@@ -32,7 +32,7 @@ protected:
   SegmentEntityStore *store = nullptr;
   ContentFixtures *fake = nullptr;
   Chain *chain1 = nullptr;
-  Segment *segment4 = nullptr;
+  const Segment *segment4 = nullptr;
   InstrumentAudio *audioKick = nullptr;
   InstrumentAudio *audioSnare = nullptr;
 

--- a/engine/test/craft/beat/CraftBeatProgramVoiceNextMainTest.cpp
+++ b/engine/test/craft/beat/CraftBeatProgramVoiceNextMainTest.cpp
@@ -31,7 +31,7 @@ protected:
   SegmentEntityStore *store = nullptr;
   ContentEntityStore *sourceMaterial = nullptr;
   Chain *chain1 = nullptr;
-  Segment *segment4 = nullptr;
+  const Segment *segment4 = nullptr;
   InstrumentAudio *audioKick = nullptr;
   InstrumentAudio *audioSnare = nullptr;
 

--- a/engine/test/craft/beat/CraftBeat_LayeredVoicesTest.cpp
+++ b/engine/test/craft/beat/CraftBeat_LayeredVoicesTest.cpp
@@ -30,7 +30,7 @@ protected:
   SegmentEntityStore *store = nullptr;
   ContentFixtures *fake = nullptr;
   Program *program42 = nullptr;
-  Segment *segment4 = nullptr;
+  const Segment *segment4 = nullptr;
   InstrumentAudio *audioHihat = nullptr;
   InstrumentAudio *audioKick = nullptr;
   InstrumentAudio *audioSnare = nullptr;

--- a/engine/test/craft/detail/CraftDetailContinueTest.cpp
+++ b/engine/test/craft/detail/CraftDetailContinueTest.cpp
@@ -31,7 +31,7 @@ protected:
   SegmentEntityStore *store = nullptr;
   ContentFixtures *fake = nullptr;
   Chain *chain1 = nullptr;
-  Segment *segment4 = nullptr;
+  const Segment *segment4 = nullptr;
 
   void SetUp() override {
     craftFactory = new CraftFactory();

--- a/engine/test/craft/detail/CraftDetailInitialTest.cpp
+++ b/engine/test/craft/detail/CraftDetailInitialTest.cpp
@@ -29,7 +29,7 @@ protected:
   FabricatorFactory *fabricatorFactory = nullptr;
   ContentEntityStore *sourceMaterial = nullptr;
   SegmentEntityStore *store = nullptr;
-  Segment *segment6 = nullptr;
+  const Segment *segment6 = nullptr;
 
   void SetUp() override {
     craftFactory = new CraftFactory();

--- a/engine/test/craft/detail/CraftDetailNextMacroTest.cpp
+++ b/engine/test/craft/detail/CraftDetailNextMacroTest.cpp
@@ -31,7 +31,7 @@ protected:
   SegmentEntityStore *store = nullptr;
   ContentFixtures *fake = nullptr;
   Chain *chain1 = nullptr;
-  Segment *segment4 = nullptr;
+  const Segment *segment4 = nullptr;
 
   void SetUp() override {
     craftFactory = new CraftFactory();

--- a/engine/test/craft/detail/CraftDetailNextMainTest.cpp
+++ b/engine/test/craft/detail/CraftDetailNextMainTest.cpp
@@ -31,7 +31,7 @@ protected:
   SegmentEntityStore *store = nullptr;
   ContentFixtures *fake = nullptr;
   Chain *chain1 = nullptr;
-  Segment *segment4 = nullptr;
+  const Segment *segment4 = nullptr;
 
   void SetUp() override {
     craftFactory = new CraftFactory();

--- a/engine/test/craft/detail/CraftDetailProgramVoiceContinueTest.cpp
+++ b/engine/test/craft/detail/CraftDetailProgramVoiceContinueTest.cpp
@@ -31,7 +31,7 @@ protected:
   SegmentEntityStore *store = nullptr;
   ContentFixtures *fake = nullptr;
   Chain *chain1 = nullptr;
-  Segment *segment4 = nullptr;
+  const Segment *segment4 = nullptr;
 
   void SetUp() override {
     craftFactory = new CraftFactory();

--- a/engine/test/craft/detail/CraftDetailProgramVoiceInitialTest.cpp
+++ b/engine/test/craft/detail/CraftDetailProgramVoiceInitialTest.cpp
@@ -6,15 +6,11 @@
 
 #include "../../_helper/ContentFixtures.h"
 #include "../../_helper/SegmentFixtures.h"
-#include "../../_helper/YamlTest.h"
 
 #include "xjmusic/craft/Craft.h"
 #include "xjmusic/craft/CraftFactory.h"
-#include "xjmusic/fabricator/ChainUtils.h"
 #include "xjmusic/fabricator/FabricatorFactory.h"
-#include "xjmusic/fabricator/SegmentUtils.h"
 #include "xjmusic/util/CsvUtils.h"
-#include "xjmusic/util/ValueUtils.h"
 
 // NOLINTNEXTLINE
 using ::testing::_;
@@ -31,7 +27,7 @@ protected:
   SegmentEntityStore *store = nullptr;
   ContentFixtures *fake = nullptr;
   Chain *chain2 = nullptr;
-  Segment *segment1 = nullptr;
+  const Segment *segment1 = nullptr;
 
   void SetUp() override {
     craftFactory = new CraftFactory();

--- a/engine/test/craft/detail/CraftDetailProgramVoiceNextMacroTest.cpp
+++ b/engine/test/craft/detail/CraftDetailProgramVoiceNextMacroTest.cpp
@@ -31,7 +31,7 @@ protected:
   SegmentEntityStore *store = nullptr;
   ContentFixtures *fake = nullptr;
   Chain *chain1 = nullptr;
-  Segment *segment4 = nullptr;
+  const Segment *segment4 = nullptr;
 
   void SetUp() override {
     craftFactory = new CraftFactory();

--- a/engine/test/craft/detail/CraftDetailProgramVoiceNextMainTest.cpp
+++ b/engine/test/craft/detail/CraftDetailProgramVoiceNextMainTest.cpp
@@ -31,7 +31,7 @@ protected:
   SegmentEntityStore *store = nullptr;
   ContentFixtures *fake = nullptr;
   Chain *chain1 = nullptr;
-  Segment *segment4 = nullptr;
+  const Segment *segment4 = nullptr;
 
   void SetUp() override {
     craftFactory = new CraftFactory();

--- a/engine/test/craft/detail_hook/CraftHookContinueTest.cpp
+++ b/engine/test/craft/detail_hook/CraftHookContinueTest.cpp
@@ -31,7 +31,7 @@ protected:
   SegmentEntityStore *store = nullptr;
   ContentFixtures *fake = nullptr;
   Chain *chain1 = nullptr;
-  Segment *segment4 = nullptr;
+  const Segment *segment4 = nullptr;
 
   void SetUp() override {
     craftFactory = new CraftFactory();

--- a/engine/test/craft/detail_hook/CraftHookInitialTest.cpp
+++ b/engine/test/craft/detail_hook/CraftHookInitialTest.cpp
@@ -29,7 +29,7 @@ protected:
   FabricatorFactory *fabricatorFactory = nullptr;
   ContentEntityStore *sourceMaterial = nullptr;
   SegmentEntityStore *store = nullptr;
-  Segment *segment6 = nullptr;
+  const Segment *segment6 = nullptr;
 
   void SetUp() override {
     craftFactory = new CraftFactory();

--- a/engine/test/craft/detail_hook/CraftHookNextMacroTest.cpp
+++ b/engine/test/craft/detail_hook/CraftHookNextMacroTest.cpp
@@ -31,7 +31,7 @@ protected:
   SegmentEntityStore *store = nullptr;
   ContentEntityStore *sourceMaterial = nullptr;
   Chain *chain1 = nullptr;
-  Segment *segment4 = nullptr;
+  const Segment *segment4 = nullptr;
 
   void SetUp() override {
     craftFactory = new CraftFactory();

--- a/engine/test/craft/detail_hook/CraftHookNextMainTest.cpp
+++ b/engine/test/craft/detail_hook/CraftHookNextMainTest.cpp
@@ -31,7 +31,7 @@ protected:
   SegmentEntityStore *store = nullptr;
   ContentFixtures *fake = nullptr;
   Chain *chain1 = nullptr;
-  Segment *segment4 = nullptr;
+  const Segment *segment4 = nullptr;
 
   void SetUp() override {
     craftFactory = new CraftFactory();

--- a/engine/test/craft/detail_hook/CraftHookProgramVoiceContinueTest.cpp
+++ b/engine/test/craft/detail_hook/CraftHookProgramVoiceContinueTest.cpp
@@ -31,7 +31,7 @@ protected:
   SegmentEntityStore *store = nullptr;
   ContentFixtures *fake = nullptr;
   Chain *chain1 = nullptr;
-  Segment *segment4 = nullptr;
+  const Segment *segment4 = nullptr;
   InstrumentAudio *audioKick = nullptr;
   InstrumentAudio *audioSnare = nullptr;
 

--- a/engine/test/craft/detail_hook/CraftHookProgramVoiceInitialTest.cpp
+++ b/engine/test/craft/detail_hook/CraftHookProgramVoiceInitialTest.cpp
@@ -31,7 +31,7 @@ protected:
   SegmentEntityStore *store = nullptr;
   ContentFixtures *fake = nullptr;
   Chain *chain2 = nullptr;
-  Segment *segment0 = nullptr;
+  const Segment *segment0 = nullptr;
 
   void SetUp() override {
     craftFactory = new CraftFactory();

--- a/engine/test/craft/detail_hook/CraftHookProgramVoiceNextMacroTest.cpp
+++ b/engine/test/craft/detail_hook/CraftHookProgramVoiceNextMacroTest.cpp
@@ -31,7 +31,7 @@ protected:
   SegmentEntityStore *store = nullptr;
   ContentFixtures *fake = nullptr;
   Chain *chain1 = nullptr;
-  Segment *segment4 = nullptr;
+  const Segment *segment4 = nullptr;
   InstrumentAudio *audioKick = nullptr;
   InstrumentAudio *audioSnare = nullptr;
 

--- a/engine/test/craft/detail_hook/CraftHookProgramVoiceNextMainTest.cpp
+++ b/engine/test/craft/detail_hook/CraftHookProgramVoiceNextMainTest.cpp
@@ -31,7 +31,7 @@ protected:
   SegmentEntityStore *store = nullptr;
   ContentEntityStore *sourceMaterial = nullptr;
   Chain *chain1 = nullptr;
-  Segment *segment4 = nullptr;
+  const Segment *segment4 = nullptr;
   InstrumentAudio *audioKick = nullptr;
   InstrumentAudio *audioSnare = nullptr;
 

--- a/engine/test/craft/detail_perc_loop/CraftPercLoopContinueTest.cpp
+++ b/engine/test/craft/detail_perc_loop/CraftPercLoopContinueTest.cpp
@@ -31,7 +31,7 @@ protected:
   SegmentEntityStore *store = nullptr;
   ContentFixtures *fake = nullptr;
   Chain *chain1 = nullptr;
-  Segment *segment4 = nullptr;
+  const Segment *segment4 = nullptr;
 
   void SetUp() override {
     craftFactory = new CraftFactory();

--- a/engine/test/craft/detail_perc_loop/CraftPercLoopInitialTest.cpp
+++ b/engine/test/craft/detail_perc_loop/CraftPercLoopInitialTest.cpp
@@ -29,7 +29,7 @@ protected:
   FabricatorFactory *fabricatorFactory = nullptr;
   ContentEntityStore *sourceMaterial = nullptr;
   SegmentEntityStore *store = nullptr;
-  Segment *segment6 = nullptr;
+  const Segment *segment6 = nullptr;
 
   void SetUp() override {
     craftFactory = new CraftFactory();

--- a/engine/test/craft/detail_perc_loop/CraftPercLoopNextMacroTest.cpp
+++ b/engine/test/craft/detail_perc_loop/CraftPercLoopNextMacroTest.cpp
@@ -31,7 +31,7 @@ protected:
   SegmentEntityStore *store = nullptr;
   ContentEntityStore *sourceMaterial = nullptr;
   Chain *chain1 = nullptr;
-  Segment *segment4 = nullptr;
+  const Segment *segment4 = nullptr;
 
   void SetUp() override {
     craftFactory = new CraftFactory();

--- a/engine/test/craft/detail_perc_loop/CraftPercLoopNextMainTest.cpp
+++ b/engine/test/craft/detail_perc_loop/CraftPercLoopNextMainTest.cpp
@@ -31,7 +31,7 @@ protected:
   SegmentEntityStore *store = nullptr;
   ContentFixtures *fake = nullptr;
   Chain *chain1 = nullptr;
-  Segment *segment4 = nullptr;
+  const Segment *segment4 = nullptr;
 
   void SetUp() override {
     craftFactory = new CraftFactory();

--- a/engine/test/craft/detail_perc_loop/CraftPercLoopProgramVoiceContinueTest.cpp
+++ b/engine/test/craft/detail_perc_loop/CraftPercLoopProgramVoiceContinueTest.cpp
@@ -31,7 +31,7 @@ protected:
   SegmentEntityStore *store = nullptr;
   ContentFixtures *fake = nullptr;
   Chain *chain1 = nullptr;
-  Segment *segment4 = nullptr;
+  const Segment *segment4 = nullptr;
   InstrumentAudio *audioKick = nullptr;
   InstrumentAudio *audioSnare = nullptr;
 

--- a/engine/test/craft/detail_perc_loop/CraftPercLoopProgramVoiceInitialTest.cpp
+++ b/engine/test/craft/detail_perc_loop/CraftPercLoopProgramVoiceInitialTest.cpp
@@ -31,7 +31,7 @@ protected:
   SegmentEntityStore *store = nullptr;
   ContentFixtures *fake = nullptr;
   Chain* chain2=nullptr;
-  Segment* segment0=nullptr;
+  const Segment* segment0=nullptr;
 
   void SetUp() override {
     craftFactory = new CraftFactory();

--- a/engine/test/craft/detail_perc_loop/CraftPercLoopProgramVoiceNextMacroTest.cpp
+++ b/engine/test/craft/detail_perc_loop/CraftPercLoopProgramVoiceNextMacroTest.cpp
@@ -6,15 +6,11 @@
 
 #include "../../_helper/ContentFixtures.h"
 #include "../../_helper/SegmentFixtures.h"
-#include "../../_helper/YamlTest.h"
 
 #include "xjmusic/craft/Craft.h"
 #include "xjmusic/craft/CraftFactory.h"
-#include "xjmusic/fabricator/ChainUtils.h"
 #include "xjmusic/fabricator/FabricatorFactory.h"
-#include "xjmusic/fabricator/SegmentUtils.h"
 #include "xjmusic/util/CsvUtils.h"
-#include "xjmusic/util/ValueUtils.h"
 
 // NOLINTNEXTLINE
 using ::testing::_;
@@ -31,7 +27,7 @@ protected:
   SegmentEntityStore *store = nullptr;
   ContentFixtures *fake = nullptr;
   Chain *chain1 = nullptr;
-  Segment *segment4 = nullptr;
+  const Segment *segment4 = nullptr;
   InstrumentAudio *audioKick = nullptr;
   InstrumentAudio *audioSnare = nullptr;
 

--- a/engine/test/craft/detail_perc_loop/CraftPercLoopProgramVoiceNextMainTest.cpp
+++ b/engine/test/craft/detail_perc_loop/CraftPercLoopProgramVoiceNextMainTest.cpp
@@ -31,7 +31,7 @@ protected:
   SegmentEntityStore *store = nullptr;
   ContentEntityStore *sourceMaterial = nullptr;
   Chain *chain1 = nullptr;
-  Segment *segment4 = nullptr;
+  const Segment *segment4 = nullptr;
   InstrumentAudio *audioKick = nullptr;
   InstrumentAudio *audioSnare = nullptr;
 

--- a/engine/test/craft/detail_perc_loop/CraftPercLoop_LayeredVoicesTest.cpp
+++ b/engine/test/craft/detail_perc_loop/CraftPercLoop_LayeredVoicesTest.cpp
@@ -31,7 +31,7 @@ protected:
   FabricatorFactory *fabricatorFactory = nullptr;
   ContentEntityStore *sourceMaterial = nullptr;
   ContentFixtures *fake = nullptr;
-  Segment *segment4 = nullptr;
+  const Segment *segment4 = nullptr;
 
   void SetUp() override {
     craftFactory = new CraftFactory();

--- a/engine/test/craft/macro_main/CraftFoundationContinueTest.cpp
+++ b/engine/test/craft/macro_main/CraftFoundationContinueTest.cpp
@@ -15,7 +15,6 @@
 #include "xjmusic/fabricator/ChainUtils.h"
 #include "xjmusic/fabricator/FabricatorFactory.h"
 #include "xjmusic/fabricator/SegmentUtils.h"
-#include "xjmusic/util/CsvUtils.h"
 #include "xjmusic/util/ValueUtils.h"
 
 // NOLINTNEXTLINE
@@ -121,7 +120,7 @@ TEST_F(CraftFoundationContinueTest, CraftFoundationContinue) {
   ASSERT_EQ(Segment::Type::Continue, result->type);
   ASSERT_EQ(32 * ValueUtils::MICROS_PER_MINUTE / 140, result->durationMicros);
   ASSERT_EQ(32, result->total);
-  ASSERT_NEAR(0.23, result->intensity, 0.001);
+  ASSERT_NEAR(0.2, result->intensity, 0.001);
   ASSERT_EQ("G -", result->key);
   ASSERT_NEAR(140, result->tempo, 0.001);
   ASSERT_EQ(Segment::Type::Continue, result->type);

--- a/engine/test/craft/macro_main/CraftFoundationContinueTest.cpp
+++ b/engine/test/craft/macro_main/CraftFoundationContinueTest.cpp
@@ -32,7 +32,7 @@ protected:
   ContentEntityStore *sourceMaterial = nullptr;
   SegmentEntityStore *store = nullptr;
   ContentFixtures *fake = nullptr;
-  Segment *segment4 = nullptr;
+  const Segment *segment4 = nullptr;
 
   void SetUp() override {
     craftFactory = new CraftFactory();

--- a/engine/test/craft/macro_main/CraftFoundationInitialTest.cpp
+++ b/engine/test/craft/macro_main/CraftFoundationInitialTest.cpp
@@ -30,7 +30,7 @@ protected:
   ContentEntityStore *sourceMaterial = nullptr;
   SegmentEntityStore *store = nullptr;
   ContentFixtures *fake = nullptr;
-  Segment *segment6 = nullptr;
+  const Segment *segment6 = nullptr;
 
   void SetUp() override {
     craftFactory = new CraftFactory();

--- a/engine/test/craft/macro_main/CraftFoundationNextMainTest.cpp
+++ b/engine/test/craft/macro_main/CraftFoundationNextMainTest.cpp
@@ -32,7 +32,7 @@ protected:
   SegmentEntityStore *store = nullptr;
   ContentEntityStore *sourceMaterial = nullptr;
   Chain *chain1 = nullptr;
-  Segment *segment4 = nullptr;
+  const Segment *segment4 = nullptr;
 
   void SetUp() override {
     store = new SegmentEntityStore();

--- a/engine/test/craft/macro_main/CraftSegmentOutputEncoderTest.cpp
+++ b/engine/test/craft/macro_main/CraftSegmentOutputEncoderTest.cpp
@@ -28,7 +28,7 @@ protected:
   FabricatorFactory *fabricatorFactory = nullptr;
   SegmentEntityStore *store = nullptr;
   ContentEntityStore *sourceMaterial = nullptr;
-  Segment *segment6 = nullptr;
+  const Segment *segment6 = nullptr;
 
   void SetUp() override {
     craftFactory = new CraftFactory();

--- a/engine/test/craft/transition/CraftTransitionContinueTest.cpp
+++ b/engine/test/craft/transition/CraftTransitionContinueTest.cpp
@@ -31,7 +31,7 @@ protected:
   SegmentEntityStore *store = nullptr;
   ContentFixtures *fake = nullptr;
   Chain *chain1 = nullptr;
-  Segment *segment4 = nullptr;
+  const Segment *segment4 = nullptr;
 
   void SetUp() override {
     craftFactory = new CraftFactory();

--- a/engine/test/craft/transition/CraftTransitionInitialTest.cpp
+++ b/engine/test/craft/transition/CraftTransitionInitialTest.cpp
@@ -29,7 +29,7 @@ protected:
   FabricatorFactory *fabricatorFactory = nullptr;
   ContentEntityStore *sourceMaterial = nullptr;
   SegmentEntityStore *store = nullptr;
-  Segment *segment6 = nullptr;
+  const Segment *segment6 = nullptr;
 
   void SetUp() override {
     craftFactory = new CraftFactory();

--- a/engine/test/craft/transition/CraftTransitionNextMacroTest.cpp
+++ b/engine/test/craft/transition/CraftTransitionNextMacroTest.cpp
@@ -31,7 +31,7 @@ protected:
   SegmentEntityStore *store = nullptr;
   ContentEntityStore *sourceMaterial = nullptr;
   Chain *chain1 = nullptr;
-  Segment *segment4 = nullptr;
+  const Segment *segment4 = nullptr;
 
   void SetUp() override {
     craftFactory = new CraftFactory();

--- a/engine/test/craft/transition/CraftTransitionNextMainTest.cpp
+++ b/engine/test/craft/transition/CraftTransitionNextMainTest.cpp
@@ -31,7 +31,7 @@ protected:
   SegmentEntityStore *store = nullptr;
   ContentFixtures *fake = nullptr;
   Chain *chain1 = nullptr;
-  Segment *segment4 = nullptr;
+  const Segment *segment4 = nullptr;
 
   void SetUp() override {
     craftFactory = new CraftFactory();

--- a/engine/test/craft/transition/CraftTransitionProgramVoiceContinueTest.cpp
+++ b/engine/test/craft/transition/CraftTransitionProgramVoiceContinueTest.cpp
@@ -30,7 +30,7 @@ protected:
   ContentEntityStore *sourceMaterial = nullptr;
   SegmentEntityStore *store = nullptr;
   ContentFixtures *fake = nullptr;
-  Segment *segment4 = nullptr;
+  const Segment *segment4 = nullptr;
   Chain *chain1 = nullptr;
   InstrumentAudio *audioKick = nullptr;
   InstrumentAudio *audioSnare = nullptr;

--- a/engine/test/craft/transition/CraftTransitionProgramVoiceInitialTest.cpp
+++ b/engine/test/craft/transition/CraftTransitionProgramVoiceInitialTest.cpp
@@ -6,15 +6,11 @@
 
 #include "../../_helper/ContentFixtures.h"
 #include "../../_helper/SegmentFixtures.h"
-#include "../../_helper/YamlTest.h"
 
 #include "xjmusic/craft/Craft.h"
 #include "xjmusic/craft/CraftFactory.h"
-#include "xjmusic/fabricator/ChainUtils.h"
 #include "xjmusic/fabricator/FabricatorFactory.h"
-#include "xjmusic/fabricator/SegmentUtils.h"
 #include "xjmusic/util/CsvUtils.h"
-#include "xjmusic/util/ValueUtils.h"
 
 // NOLINTNEXTLINE
 using ::testing::_;
@@ -31,7 +27,7 @@ protected:
   SegmentEntityStore *store = nullptr;
   ContentFixtures *fake = nullptr;
   Chain *chain2 = nullptr;
-  Segment *segment0 = nullptr;
+  const Segment *segment0 = nullptr;
 
   void SetUp() override {
     craftFactory = new CraftFactory();

--- a/engine/test/craft/transition/CraftTransitionProgramVoiceNextMacroTest.cpp
+++ b/engine/test/craft/transition/CraftTransitionProgramVoiceNextMacroTest.cpp
@@ -31,7 +31,7 @@ protected:
   SegmentEntityStore *store = nullptr;
   ContentFixtures *fake = nullptr;
   Chain *chain1 = nullptr;
-  Segment *segment4 = nullptr;
+  const Segment *segment4 = nullptr;
   InstrumentAudio *audioKick = nullptr;
   InstrumentAudio *audioSnare = nullptr;
 

--- a/engine/test/craft/transition/CraftTransitionProgramVoiceNextMainTest.cpp
+++ b/engine/test/craft/transition/CraftTransitionProgramVoiceNextMainTest.cpp
@@ -31,7 +31,7 @@ protected:
   SegmentEntityStore *store = nullptr;
   ContentEntityStore *sourceMaterial = nullptr;
   Chain *chain1 = nullptr;
-  Segment *segment4 = nullptr;
+  const Segment *segment4 = nullptr;
   InstrumentAudio *audioKick = nullptr;
   InstrumentAudio *audioSnare = nullptr;
 

--- a/engine/test/craft/transition/CraftTransition_LayeredVoicesTest.cpp
+++ b/engine/test/craft/transition/CraftTransition_LayeredVoicesTest.cpp
@@ -31,7 +31,7 @@ protected:
   FabricatorFactory *fabricatorFactory = nullptr;
   ContentEntityStore *sourceMaterial = nullptr;
   ContentFixtures *fake = nullptr;
-  Segment *segment4 = nullptr;
+  const Segment *segment4 = nullptr;
 
   void SetUp() override {
     craftFactory = new CraftFactory();

--- a/engine/test/fabricator/FabricatorTest.cpp
+++ b/engine/test/fabricator/FabricatorTest.cpp
@@ -30,7 +30,7 @@ protected:
   MockSegmentRetrospective *mockRetrospective = nullptr;
   Fabricator *subject = nullptr;
   ContentFixtures *fake = nullptr;
-  Segment *segment = nullptr;
+  const Segment *segment = nullptr;
 
 protected:
   void SetUp() override {
@@ -100,9 +100,9 @@ TEST_F(FabricatorTest, PickReturnedByPicks) {
   pick.tones = "A4";
   store->put(pick);
 
-  std::set<SegmentChoiceArrangementPick *> result = subject->getPicks();
+  std::set<const SegmentChoiceArrangementPick *> result = subject->getPicks();
 
-  SegmentChoiceArrangementPick *resultPick = *result.begin();
+  const SegmentChoiceArrangementPick *resultPick = *result.begin();
   ASSERT_EQ(beatArrangement->id, resultPick->segmentChoiceArrangementId);
   ASSERT_EQ(fake->instrument8_audio8kick.id, resultPick->instrumentAudioId);
   ASSERT_NEAR(0.273 * ValueUtils::MICROS_PER_SECOND, resultPick->startAtSegmentMicros, 0.001);
@@ -424,9 +424,9 @@ TEST_F(FabricatorTest, PutAddsMemesForChoice) {
   ASSERT_EQ("WILD", sortedResultMemes[4].name);
 
   const auto resultChoices = store->readAllSegmentChoices(segment->id);
-  std::vector<SegmentChoice *> sortedResultChoices;
-  for (SegmentChoice *pointer: resultChoices) {
-    sortedResultChoices.push_back(pointer);
+  std::vector<const SegmentChoice *> sortedResultChoices;
+  for (const SegmentChoice *pointer: resultChoices) {
+    sortedResultChoices.emplace_back(pointer);
   }
   std::sort(sortedResultChoices.begin(), sortedResultChoices.end(), [](const SegmentChoice *a, const SegmentChoice *b) {
     return a->programType < b->programType;

--- a/engine/test/fabricator/SegmentUtilsTest.cpp
+++ b/engine/test/fabricator/SegmentUtilsTest.cpp
@@ -1,6 +1,5 @@
 // Copyright (c) XJ Music Inc. (https://xjmusic.com) All Rights Reserved.
 
-#include <fstream>
 #include <gtest/gtest.h>
 #include <string>
 
@@ -14,7 +13,7 @@ using namespace XJ;
 
 class SegmentUtilsTest : public testing::Test {
 protected:
-  std::vector<Segment *> segments;
+  std::vector<const Segment *> segments;
   Project project;
   Template tmpl;
   Chain chain;
@@ -112,7 +111,7 @@ TEST_F(SegmentUtilsTest, FindFirstOfType) {
   ch1.deltaOut = SegmentChoice::DELTA_UNLIMITED;
   ch1.programType = Program::Type::Macro;
 
-  std::set choices = {&ch0, &ch1};
+  std::set<const SegmentChoice *> choices = {&ch0, &ch1};
   ASSERT_EQ(ch0.id, SegmentUtils::findFirstOfType(choices, Program::Type::Main).value()->id);
 }
 
@@ -123,7 +122,7 @@ TEST_F(SegmentUtilsTest, GetIdentifier) {
 
 // Test for getLastDubbed
 TEST_F(SegmentUtilsTest, GetLastDubbed) {
-  const std::optional<Segment *> lastCrafted = SegmentUtils::getLastCrafted(segments);
+  const std::optional<const Segment *> lastCrafted = SegmentUtils::getLastCrafted(segments);
 
   ASSERT_TRUE(lastCrafted.has_value());
   ASSERT_EQ(seg2.id, lastCrafted.value()->id);
@@ -131,7 +130,7 @@ TEST_F(SegmentUtilsTest, GetLastDubbed) {
 
 // Test for getLast
 TEST_F(SegmentUtilsTest, GetLast) {
-  const std::optional<Segment *> last = SegmentUtils::getLast(segments);
+  const std::optional<const Segment *> last = SegmentUtils::getLast(segments);
 
   ASSERT_TRUE(last.has_value());
   ASSERT_EQ(seg3.id, last.value()->id);

--- a/engine/test/segment/SegmentEntityStoreTest.cpp
+++ b/engine/test/segment/SegmentEntityStoreTest.cpp
@@ -4,7 +4,6 @@
 #include <vector>
 
 #include <gtest/gtest.h>
-#include <spdlog/spdlog.h>
 
 #include "xjmusic/fabricator/FabricationException.h"
 #include "xjmusic/segment/SegmentEntityStore.h"
@@ -66,7 +65,7 @@ protected:
         120.0,
         "chains-1-segments-9f7s89d8a7892.wav",
         true));
-    const auto segment2mutable = subject->put(SegmentFixtures::buildSegment(
+    auto segment2mutable = *subject->put(SegmentFixtures::buildSegment(
         chain3,
         Segment::Type::Continue,
         1,
@@ -78,8 +77,8 @@ protected:
         120.0,
         "chains-1-segments-9f7s89d8a7892.wav",
         true));
-    segment2mutable->waveformPreroll = 1.523;
-    segment2 = subject->put(*segment2mutable);
+    segment2mutable.waveformPreroll = 1.523;
+    segment2 = subject->put(segment2mutable);
     segment3 = subject->put(SegmentFixtures::buildSegment(
         chain3,
         Segment::Type::Continue,
@@ -142,7 +141,7 @@ TEST_F(SegmentEntityStoreTest, Create) {
   inputData.key = "C# minor 7 b9";
   inputData.tempo = 120.0;
 
-  Segment *result = subject->put(inputData);
+  const auto result = subject->put(inputData);
 
   EXPECT_EQ(chain3->id, result->chainId);
   EXPECT_EQ(5, result->id);
@@ -174,7 +173,7 @@ TEST_F(SegmentEntityStoreTest, Create_Get_Segment) {
   segment.storageKey = "chains-1-segments-9f7s89d8a7892.wav";
 
   subject->put(segment);
-  Segment *result = subject->readSegment(segment.id).value();
+  const auto result = subject->readSegment(segment.id).value();
 
   ASSERT_EQ(segment.id, result->id);
   ASSERT_EQ(chainId, result->chainId);
@@ -222,7 +221,7 @@ TEST_F(SegmentEntityStoreTest, CreateAll_ReadAll) {
   auto program = ContentFixtures::buildProgram(Program::Type::Macro, "C", 120.0f);
   auto programSequence = ContentFixtures::buildProgramSequence(&program, 8, "Hay", 0.6f, "G");
   auto programSequenceBinding = ContentFixtures::buildProgramSequenceBinding(&programSequence, 0);
-  Segment *chain3_segment0 = subject->put(SegmentFixtures::buildSegment(chain3,
+  const auto chain3_segment0 = subject->put(SegmentFixtures::buildSegment(chain3,
                                                                         0,
                                                                         Segment::State::Crafted,
                                                                         "D Major",

--- a/engine/test/segment/SegmentEntityStoreTest.cpp
+++ b/engine/test/segment/SegmentEntityStoreTest.cpp
@@ -222,13 +222,13 @@ TEST_F(SegmentEntityStoreTest, CreateAll_ReadAll) {
   auto programSequence = ContentFixtures::buildProgramSequence(&program, 8, "Hay", 0.6f, "G");
   auto programSequenceBinding = ContentFixtures::buildProgramSequenceBinding(&programSequence, 0);
   const auto chain3_segment0 = subject->put(SegmentFixtures::buildSegment(chain3,
-                                                                        0,
-                                                                        Segment::State::Crafted,
-                                                                        "D Major",
-                                                                        64,
-                                                                        0.73f,
-                                                                        120.0f,
-                                                                        "chains-3-segments-9f7s89d8a7892.wav"));
+                                                                          0,
+                                                                          Segment::State::Crafted,
+                                                                          "D Major",
+                                                                          64,
+                                                                          0.73f,
+                                                                          120.0f,
+                                                                          "chains-3-segments-9f7s89d8a7892.wav"));
   subject->put(
       SegmentFixtures::buildSegmentChoice(chain3_segment0, SegmentChoice::DELTA_UNLIMITED,
                                           SegmentChoice::DELTA_UNLIMITED, &program,
@@ -286,11 +286,11 @@ TEST_F(SegmentEntityStoreTest, ReadSegmentsFromToOffset) {
 
   ASSERT_EQ(2, result.size());
   auto it = result.begin();
-  Segment result1 = *it;
-  ASSERT_EQ(Segment::State::Crafted, result1.state);
+  const Segment *result1 = *it;
+  ASSERT_EQ(Segment::State::Crafted, result1->state);
   ++it;
-  Segment result2 = *it;
-  ASSERT_EQ(Segment::State::Crafting, result2.state);
+  const Segment *result2 = *it;
+  ASSERT_EQ(Segment::State::Crafting, result2->state);
 }
 
 

--- a/engine/test/segment/SegmentMemeTest.cpp
+++ b/engine/test/segment/SegmentMemeTest.cpp
@@ -62,7 +62,7 @@ TEST(SegmentMemeTest, testGetNames) {
   segmentMeme2.segmentId = 2;
   segmentMeme2.name = "name2";
 
-  std::set<SegmentMeme*> segmentMemes;
+  std::set<const SegmentMeme*> segmentMemes;
   segmentMemes.insert(&segmentMeme1);
   segmentMemes.insert(&segmentMeme2);
 

--- a/engine/test/util/ValueUtilsTest.cpp
+++ b/engine/test/util/ValueUtilsTest.cpp
@@ -140,9 +140,9 @@ TEST(ValueUtils, multipleFloor) {
 }
 
 TEST(ValueUtils, interpolate) {
-  ASSERT_NEAR(10, ValueUtils::interpolate(10, 20, 0, 1.0), 0.000001);
-  ASSERT_NEAR(20, ValueUtils::interpolate(10, 20, 1, 1.0), 0.000001);
-  ASSERT_NEAR(15, ValueUtils::interpolate(10, 20, 1, 0.5), 0.000001);
+  ASSERT_NEAR(10, ValueUtils::interpolate(10, 20, 0), 0.000001);
+  ASSERT_NEAR(20, ValueUtils::interpolate(10, 20, 1), 0.000001);
+  ASSERT_NEAR(15, ValueUtils::interpolate(10, 20, 0.5), 0.000001);
 }
 
 TEST(ValueUtils, enforceMaxStereo) {


### PR DESCRIPTION
- ActiveAudio measured in chain micros (no concept of mixer frame)
- Work cycle renders all ActiveAudio present from atChainMicros to atChainMicros + dubAheadMicros

Engine Example App in C++
https://github.com/xjmusic/xjmusic/issues/377