### PR TITLE
Don't unnecessarily reconvert audio during build

### DIFF
--- a/workstation/src/main/java/io/xj/gui/controllers/template/TemplateExportModalController.java
+++ b/workstation/src/main/java/io/xj/gui/controllers/template/TemplateExportModalController.java
@@ -133,16 +133,15 @@ public class TemplateExportModalController extends ProjectModalController {
   void handlePressOK() {
     var projectName = StringUtils.toLowerScored(templateExportName.getText());
     Boolean conversion = Objects.equals(selectAudioFormat.getValue(), audioFormatOptions.get(1));
-    @Nullable Integer conversionFrameRate = conversion ? Integer.valueOf(projectService.outputFrameRateProperty().getValue()) : null;
-    @Nullable Integer conversionSampleBits = conversion ? FIXED_SAMPLE_BITS : null;
-    @Nullable Integer conversionChannel = conversion ? Integer.valueOf(projectService.outputChannelsProperty().getValue()) : null;
+    int conversionFrameRate = Integer.parseInt(projectService.outputFrameRateProperty().getValue());
+    int conversionChannel = Integer.parseInt(projectService.outputChannelsProperty().getValue());
     projectService.exportTemplate(
       template.get(),
       fieldPathPrefix.getText(),
       projectName,
       conversion,
       conversionFrameRate,
-      conversionSampleBits,
+      FIXED_SAMPLE_BITS,
       conversionChannel
     );
     Stage stage = (Stage) buttonCancel.getScene().getWindow();

--- a/workstation/src/main/java/io/xj/gui/project/ProjectManager.java
+++ b/workstation/src/main/java/io/xj/gui/project/ProjectManager.java
@@ -65,9 +65,9 @@ public interface ProjectManager {
     String parentPathPrefix,
     String exportName,
     Boolean conversion,
-    @Nullable Integer conversionFrameRate,
-    @Nullable Integer conversionSampleBits,
-    @Nullable Integer conversionChannels
+    int conversionFrameRate,
+    int conversionSampleBits,
+    int conversionChannels
   );
 
   /**

--- a/workstation/src/main/java/io/xj/gui/services/ProjectService.java
+++ b/workstation/src/main/java/io/xj/gui/services/ProjectService.java
@@ -82,9 +82,9 @@ public interface ProjectService {
     String parentPathPrefix,
     String exportName,
     Boolean conversion,
-    @Nullable Integer conversionFrameRate,
-    @Nullable Integer conversionSampleBits,
-    @Nullable Integer conversionChannels
+    int conversionFrameRate,
+    int conversionSampleBits,
+    int conversionChannels
   );
 
 

--- a/workstation/src/main/java/io/xj/gui/services/impl/ProjectServiceImpl.java
+++ b/workstation/src/main/java/io/xj/gui/services/impl/ProjectServiceImpl.java
@@ -289,9 +289,9 @@ public class ProjectServiceImpl implements ProjectService {
     String parentPathPrefix,
     String exportName,
     Boolean conversion,
-    @Nullable Integer conversionFrameRate,
-    @Nullable Integer conversionSampleBits,
-    @Nullable Integer conversionChannels
+    int conversionFrameRate,
+    int conversionSampleBits,
+    int conversionChannels
   ) {
     if (promptToSkipOverwriteIfExists(parentPathPrefix, exportName, "Template Export"))
       executeInBackground("Export Template", () -> {


### PR DESCRIPTION
Expectation is that if I press Build twice in a row, the second time it's very fast, because all the audio is already converted in the target location

Closes #426