### PR TITLE
Engine distro CI ships static library to release on GitHub

### DIFF
--- a/.github/workflows/engine_distro.yml
+++ b/.github/workflows/engine_distro.yml
@@ -143,11 +143,10 @@ jobs:
         run: |
           cmake .. -DCMAKE_BUILD_TYPE=Release
           cmake --build .
-          cp libxjmusic.a xjmusic-v${{ needs.verify_version_number.outputs.version }}.lib
+          cp src/libxjmusic.a ../../xjmusic-v${{ needs.verify_version_number.outputs.version }}.lib
 
       - name: Compress .lib file (macOS/Intel)
         if: runner.os == 'macOS' && runner.arch == 'X64'
-        working-directory: engine/build/
         run: |
           zip xjmusic-v${{ needs.verify_version_number.outputs.version }}-macos-intel.lib.zip xjmusic-v${{ needs.verify_version_number.outputs.version }}.lib
 
@@ -156,7 +155,7 @@ jobs:
         uses: svenstaro/upload-release-action@v2
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: engine/build/xjmusic-v${{ needs.verify_version_number.outputs.version }}-macos-intel.lib.zip
+          file: xjmusic-v${{ needs.verify_version_number.outputs.version }}-macos-intel.lib.zip
           asset_name: xjmusic-v${{ needs.verify_version_number.outputs.version }}-macos-intel.lib.zip
           tag: ${{ github.ref }}
           overwrite: true
@@ -164,11 +163,10 @@ jobs:
       - name: Upload to Amazon S3 (macOS/Intel)
         if: runner.os == 'macOS' && runner.arch == 'X64'
         run:
-          aws s3 cp engine/build/xjmusic-v${{ needs.verify_version_number.outputs.version }}-macos-intel.lib.zip s3://${{ secrets.AWS_S3_BUCKET }}/
+          aws s3 cp xjmusic-v${{ needs.verify_version_number.outputs.version }}-macos-intel.lib.zip s3://${{ secrets.AWS_S3_BUCKET }}/
 
       - name: Compress .lib file (macOS/Silicon)
         if: runner.os == 'macOS' && runner.arch == 'ARM64'
-        working-directory: engine/build/
         run: |
           zip xjmusic-v${{ needs.verify_version_number.outputs.version }}-macos-silicon.lib.zip xjmusic-v${{ needs.verify_version_number.outputs.version }}.lib
 
@@ -177,7 +175,7 @@ jobs:
         uses: svenstaro/upload-release-action@v2
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: engine/build/xjmusic-v${{ needs.verify_version_number.outputs.version }}-macos-silicon.lib.zip
+          file: xjmusic-v${{ needs.verify_version_number.outputs.version }}-macos-silicon.lib.zip
           asset_name: xjmusic-v${{ needs.verify_version_number.outputs.version }}-macos-silicon.lib.zip
           tag: ${{ github.ref }}
           overwrite: true
@@ -185,11 +183,10 @@ jobs:
       - name: Upload to Amazon S3 (macOS/Silicon)
         if: runner.os == 'macOS' && runner.arch == 'ARM64'
         run:
-          aws s3 cp engine/build/xjmusic-v${{ needs.verify_version_number.outputs.version }}-macos-silicon.lib.zip s3://${{ secrets.AWS_S3_BUCKET }}/
+          aws s3 cp xjmusic-v${{ needs.verify_version_number.outputs.version }}-macos-silicon.lib.zip s3://${{ secrets.AWS_S3_BUCKET }}/
 
       - name: Compress .lib file for Windows
         if: runner.os == 'Windows'
-        working-directory: engine/build/
         run: |
           Compress-Archive -Path xjmusic-v${{ needs.verify_version_number.outputs.version }}.lib -DestinationPath xjmusic-v${{ needs.verify_version_number.outputs.version }}-windows.lib.zip
 
@@ -198,7 +195,7 @@ jobs:
         uses: svenstaro/upload-release-action@v2
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: engine/build/xjmusic-v${{ needs.verify_version_number.outputs.version }}-windows.lib.zip
+          file: xjmusic-v${{ needs.verify_version_number.outputs.version }}-windows.lib.zip
           asset_name: xjmusic-v${{ needs.verify_version_number.outputs.version }}-windows.lib.zip
           tag: ${{ github.ref }}
           overwrite: true
@@ -206,11 +203,10 @@ jobs:
       - name: Upload to Amazon S3 (Windows)
         if: runner.os == 'Windows'
         run:
-          aws s3 cp engine/build/xjmusic-v${{ needs.verify_version_number.outputs.version }}-windows.lib.zip s3://${{ secrets.AWS_S3_BUCKET }}/
+          aws s3 cp xjmusic-v${{ needs.verify_version_number.outputs.version }}-windows.lib.zip s3://${{ secrets.AWS_S3_BUCKET }}/
 
       - name: Compress .lib file for Linux
         if: runner.os == 'Linux'
-        working-directory: engine/build/
         run: |
           tar -czvf xjmusic-v${{ needs.verify_version_number.outputs.version }}-linux.lib.tar.gz xjmusic-v${{ needs.verify_version_number.outputs.version }}.lib
 
@@ -219,7 +215,7 @@ jobs:
         uses: svenstaro/upload-release-action@v2
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: engine/build/xjmusic-v${{ needs.verify_version_number.outputs.version }}-linux.lib.tar.gz
+          file: xjmusic-v${{ needs.verify_version_number.outputs.version }}-linux.lib.tar.gz
           asset_name: xjmusic-v${{ needs.verify_version_number.outputs.version }}-linux.lib.tar.gz
           tag: ${{ github.ref }}
           overwrite: true
@@ -227,4 +223,4 @@ jobs:
       - name: Upload to Amazon S3 (Linux)
         if: runner.os == 'Linux'
         run:
-          aws s3 cp engine/build/xjmusic-v${{ needs.verify_version_number.outputs.version }}-linux.lib.tar.gz s3://${{ secrets.AWS_S3_BUCKET }}/
+          aws s3 cp xjmusic-v${{ needs.verify_version_number.outputs.version }}-linux.lib.tar.gz s3://${{ secrets.AWS_S3_BUCKET }}/

--- a/.github/workflows/engine_distro.yml
+++ b/.github/workflows/engine_distro.yml
@@ -98,6 +98,13 @@ jobs:
         with:
           python-version: '3.x'
 
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets. AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets. AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_REGION }}
+
       - name: Install dependencies (Windows)
         if: runner.os == 'Windows'
         working-directory: engine/

--- a/.github/workflows/engine_distro.yml
+++ b/.github/workflows/engine_distro.yml
@@ -78,12 +78,12 @@ jobs:
           fi
 
 
-  build_and_test:
+  test_and_ship_static_library:
     needs: verify_version_number
     env:
       REPO_TOKEN: ${{ secrets.REPO_TOKEN }}
       REPO_USERNAME: ${{ secrets.REPO_USERNAME }}
-    name: Build & Test [${{ matrix.os }}]
+    name: Test & Ship Library [${{ matrix.os }}]
     runs-on: ${{ matrix.os }}
     permissions: write-all
     strategy:
@@ -137,3 +137,100 @@ jobs:
         run: |
           cd build
           ctest --verbose
+
+      - name: Build the Static Library
+        working-directory: engine/
+        run: |
+          mkdir build
+          cd build
+          cmake .. -DCMAKE_BUILD_TYPE=Release
+          make
+          cp libxjmusic.a xjmusic-v${{ needs.verify_version_number.outputs.version }}.lib
+
+      - name: Compress .lib file (macOS/Intel)
+        if: runner.os == 'macOS' && runner.arch == 'X64'
+        working-directory: engine/
+        run: |
+          cd build/
+          zip xjmusic-v${{ needs.verify_version_number.outputs.version }}-macos-intel.lib.zip xjmusic-v${{ needs.verify_version_number.outputs.version }}.lib
+
+      - name: Upload to release (macOS/Intel)
+        if: runner.os == 'macOS' && runner.arch == 'X64'
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: engine/build/xjmusic-v${{ needs.verify_version_number.outputs.version }}-macos-intel.lib.zip
+          asset_name: xjmusic-v${{ needs.verify_version_number.outputs.version }}-macos-intel.lib.zip
+          tag: ${{ github.ref }}
+          overwrite: true
+
+      - name: Upload to Amazon S3 (macOS/Intel)
+        if: runner.os == 'macOS' && runner.arch == 'X64'
+        run:
+          aws s3 cp engine/build/xjmusic-v${{ needs.verify_version_number.outputs.version }}-macos-intel.lib.zip s3://${{ secrets.AWS_S3_BUCKET }}/
+
+      - name: Compress .lib file (macOS/Silicon)
+        if: runner.os == 'macOS' && runner.arch == 'ARM64'
+        working-directory: engine/
+        run: |
+          cd build/
+          zip xjmusic-v${{ needs.verify_version_number.outputs.version }}-macos-silicon.lib.zip xjmusic-v${{ needs.verify_version_number.outputs.version }}.lib
+
+      - name: Upload to release (macOS/Silicon)
+        if: runner.os == 'macOS' && runner.arch == 'ARM64'
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: engine/build/xjmusic-v${{ needs.verify_version_number.outputs.version }}-macos-silicon.lib.zip
+          asset_name: xjmusic-v${{ needs.verify_version_number.outputs.version }}-macos-silicon.lib.zip
+          tag: ${{ github.ref }}
+          overwrite: true
+
+      - name: Upload to Amazon S3 (macOS/Silicon)
+        if: runner.os == 'macOS' && runner.arch == 'ARM64'
+        run:
+          aws s3 cp engine/build/xjmusic-v${{ needs.verify_version_number.outputs.version }}-macos-silicon.lib.zip s3://${{ secrets.AWS_S3_BUCKET }}/
+
+      - name: Compress .lib file for Windows
+        if: runner.os == 'Windows'
+        working-directory: engine/
+        run: |
+          cd build/
+          Compress-Archive -Path xjmusic-v${{ needs.verify_version_number.outputs.version }}.lib -DestinationPath xjmusic-v${{ needs.verify_version_number.outputs.version }}-windows.lib.zip
+
+      - name: Upload to release (Windows)
+        if: runner.os == 'Windows'
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: engine/build/xjmusic-v${{ needs.verify_version_number.outputs.version }}-windows.lib.zip
+          asset_name: xjmusic-v${{ needs.verify_version_number.outputs.version }}-windows.lib.zip
+          tag: ${{ github.ref }}
+          overwrite: true
+
+      - name: Upload to Amazon S3 (Windows)
+        if: runner.os == 'Windows'
+        run:
+          aws s3 cp engine/build/xjmusic-v${{ needs.verify_version_number.outputs.version }}-windows.lib.zip s3://${{ secrets.AWS_S3_BUCKET }}/
+
+      - name: Compress .lib file for Linux
+        if: runner.os == 'Linux'
+        working-directory: engine/
+        run: |
+          cd build/
+          tar -czvf xjmusic-v${{ needs.verify_version_number.outputs.version }}-linux.lib.tar.gz xjmusic-v${{ needs.verify_version_number.outputs.version }}.lib
+
+      - name: Upload to release (Linux)
+        if: runner.os == 'Linux'
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: engine/build/xjmusic-v${{ needs.verify_version_number.outputs.version }}-linux.lib.tar.gz
+          asset_name: xjmusic-v${{ needs.verify_version_number.outputs.version }}-linux.lib.tar.gz
+          tag: ${{ github.ref }}
+          overwrite: true
+
+      - name: Upload to Amazon S3 (Linux)
+        if: runner.os == 'Linux'
+        run:
+          aws s3 cp engine/build/xjmusic-v${{ needs.verify_version_number.outputs.version }}-linux.lib.tar.gz s3://${{ secrets.AWS_S3_BUCKET }}/

--- a/.github/workflows/engine_distro.yml
+++ b/.github/workflows/engine_distro.yml
@@ -138,20 +138,17 @@ jobs:
           cd build
           ctest --verbose
 
-      - name: Build the Static Library
-        working-directory: engine/
+      - name: Build for Release
+        working-directory: engine/build/
         run: |
-          mkdir build
-          cd build
           cmake .. -DCMAKE_BUILD_TYPE=Release
           cmake --build .
           cp libxjmusic.a xjmusic-v${{ needs.verify_version_number.outputs.version }}.lib
 
       - name: Compress .lib file (macOS/Intel)
         if: runner.os == 'macOS' && runner.arch == 'X64'
-        working-directory: engine/
+        working-directory: engine/build/
         run: |
-          cd build/
           zip xjmusic-v${{ needs.verify_version_number.outputs.version }}-macos-intel.lib.zip xjmusic-v${{ needs.verify_version_number.outputs.version }}.lib
 
       - name: Upload to release (macOS/Intel)
@@ -171,9 +168,8 @@ jobs:
 
       - name: Compress .lib file (macOS/Silicon)
         if: runner.os == 'macOS' && runner.arch == 'ARM64'
-        working-directory: engine/
+        working-directory: engine/build/
         run: |
-          cd build/
           zip xjmusic-v${{ needs.verify_version_number.outputs.version }}-macos-silicon.lib.zip xjmusic-v${{ needs.verify_version_number.outputs.version }}.lib
 
       - name: Upload to release (macOS/Silicon)
@@ -193,9 +189,8 @@ jobs:
 
       - name: Compress .lib file for Windows
         if: runner.os == 'Windows'
-        working-directory: engine/
+        working-directory: engine/build/
         run: |
-          cd build/
           Compress-Archive -Path xjmusic-v${{ needs.verify_version_number.outputs.version }}.lib -DestinationPath xjmusic-v${{ needs.verify_version_number.outputs.version }}-windows.lib.zip
 
       - name: Upload to release (Windows)
@@ -215,9 +210,8 @@ jobs:
 
       - name: Compress .lib file for Linux
         if: runner.os == 'Linux'
-        working-directory: engine/
+        working-directory: engine/build/
         run: |
-          cd build/
           tar -czvf xjmusic-v${{ needs.verify_version_number.outputs.version }}-linux.lib.tar.gz xjmusic-v${{ needs.verify_version_number.outputs.version }}.lib
 
       - name: Upload to release (Linux)

--- a/.github/workflows/engine_distro.yml
+++ b/.github/workflows/engine_distro.yml
@@ -145,7 +145,16 @@ jobs:
           cd build
           ctest --verbose
 
-      - name: Build for Release
+      - name: Build for Release (macOS/Linux)
+        if: runner.os == 'Linux' || runner.os == 'macOS'
+        working-directory: engine/build/
+        run: |
+          cmake .. -DCMAKE_BUILD_TYPE=Release
+          cmake --build .
+          cp src/libxjmusic.a ../../xjmusic-v${{ needs.verify_version_number.outputs.version }}.lib
+
+      - name: Build for Release (Windows)
+        if: runner.os == 'Windows'
         working-directory: engine/build/
         run: |
           cmake .. -DCMAKE_BUILD_TYPE=Release

--- a/.github/workflows/engine_distro.yml
+++ b/.github/workflows/engine_distro.yml
@@ -27,8 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       workstation-version: ${{ steps.get-workstation-version.outputs.version }}
-      engine-version: ${{ steps.get-engine-version.outputs.version }}
-      engine-docs-version: ${{ steps.get-engine-docs-version.outputs.version }}
+      version: ${{ steps.get-engine-version.outputs.version }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/engine_distro.yml
+++ b/.github/workflows/engine_distro.yml
@@ -144,7 +144,7 @@ jobs:
           mkdir build
           cd build
           cmake .. -DCMAKE_BUILD_TYPE=Release
-          make
+          cmake --build .
           cp libxjmusic.a xjmusic-v${{ needs.verify_version_number.outputs.version }}.lib
 
       - name: Compress .lib file (macOS/Intel)

--- a/.github/workflows/engine_distro.yml
+++ b/.github/workflows/engine_distro.yml
@@ -150,7 +150,7 @@ jobs:
         run: |
           cmake .. -DCMAKE_BUILD_TYPE=Release
           cmake --build .
-          cp src/libxjmusic.a ../../xjmusic-v${{ needs.verify_version_number.outputs.version }}.lib
+          cp src/Debug/xjmusic.lib ../../xjmusic-v${{ needs.verify_version_number.outputs.version }}.lib
 
       - name: Compress .lib file (macOS/Intel)
         if: runner.os == 'macOS' && runner.arch == 'X64'


### PR DESCRIPTION
This workflow engine_distro.yml should test, build, & ship the C++ static library to any platform release.

Closes #433