### PR TITLE
Charney updates to Unreal Plugin branch

### DIFF
--- a/plugins/unreal/XJGame/Plugins/XJMusicPlugin/Source/XJMusicPlugin/Private/Manager/XjManager.cpp
+++ b/plugins/unreal/XJGame/Plugins/XJMusicPlugin/Source/XJMusicPlugin/Private/Manager/XjManager.cpp
@@ -8,15 +8,15 @@
 #include <Tests/MockDataEngine.h>
 #include <Settings/XJMusicDefaultSettings.h>
 
-FXjRunnable::FXjRunnable(const FString& PathToProjectFile, const UWorld* World)
+FXjRunnable::FXjRunnable(const FString& PathToProject, const UWorld* World)
 {
 	check(World);
 
-	std::string PathToProjectStr(TCHAR_TO_UTF8(*PathToProjectFile));
+	std::string PathToProjectStr(TCHAR_TO_UTF8(*PathToProject));
 	UE_LOG(LogTemp, Display, TEXT("Path to project: %s"), *FString(PathToProjectStr.c_str()));
 
 	// Crawl the build folder in the folder containing the project file
-	FString ProjectPath = PathToProjectFile;
+	FString ProjectPath = PathToProject;
 	FString FolderContainingProject = FPaths::GetPath(ProjectPath);
 	FString PathToBuildFolder = FPaths::Combine(FolderContainingProject, TEXT("build/"));
 
@@ -41,7 +41,7 @@ FXjRunnable::FXjRunnable(const FString& PathToProjectFile, const UWorld* World)
 	if (Engine)
 	{
 		XjMusicSubsystem->SetActiveEngine(Engine);
-		Engine->Setup(PathToProjectFile);
+		Engine->Setup(PathToProject);
 	}
 }
 
@@ -78,9 +78,9 @@ uint32 FXjRunnable::Run()
 				if (XjMusicSubsystem->PlayAudioByName(Audio.WaveId, Audio.StartTime.GetMillie(), Duration))
 				{
 					PlayingAudios += FString::Printf(TEXT("%s start: %f end: %f\n"),
-					                                 *Audio.Name,
-					                                 Audio.StartTime.GetSeconds(),
-					                                 Audio.EndTime.GetSeconds());
+													*Audio.Name, 
+													 Audio.StartTime.GetSeconds(), 
+													 Audio.EndTime.GetSeconds());
 				}
 
 				XjMusicSubsystem->AddActiveAudio(Audio);
@@ -88,16 +88,17 @@ uint32 FXjRunnable::Run()
 				break;
 
 			case EAudioEventType::Update:
-
+				
 				XjMusicSubsystem->UpdateActiveAudio(Audio);
 
 				break;
 
 			case EAudioEventType::Delete:
-
+				
 				XjMusicSubsystem->RemoveActiveAudio(Audio);
 
 				break;
+
 			}
 		}
 

--- a/plugins/unreal/XJGame/Plugins/XJMusicPlugin/Source/XJMusicPlugin/Private/XJMusicPlugin.cpp
+++ b/plugins/unreal/XJGame/Plugins/XJMusicPlugin/Source/XJMusicPlugin/Private/XJMusicPlugin.cpp
@@ -44,7 +44,7 @@ void FXJMusicPluginModule::StartupModule()
 }
 
 
-void FXJMusicPluginModule::OnPostWorldInitialization(UWorld* World, const UWorld::InitializationValues IVS)
+void FXJMusicPluginModule::OnPostWorldInitialization(UWorld* World, const UWorld::InitializationValues Ivs)
 {
 	if (!World)
 	{

--- a/plugins/unreal/XJGame/Plugins/XJMusicPlugin/Source/XJMusicPlugin/Private/XJMusicPlugin.cpp
+++ b/plugins/unreal/XJGame/Plugins/XJMusicPlugin/Source/XJMusicPlugin/Private/XJMusicPlugin.cpp
@@ -103,9 +103,8 @@ void FXJMusicPluginModule::PluginButtonClicked()
 		return;
 	}
 
-	FString DirAbsolute = XjSettings->XjProjectFolder;
 
-	FPlatformProcess::CreateProc(*XjSettings->PathToXjMusicWorkstation, *DirAbsolute, true, false, false, nullptr, 0, nullptr, nullptr);
+	FPlatformProcess::CreateProc(*XjSettings->PathToXjMusicWorkstation, *XjSettings->PathToXjProjectFile, true, false, false, nullptr, 0, nullptr, nullptr);
 }
 
 void FXJMusicPluginModule::RegisterMenus()

--- a/plugins/unreal/XJGame/Plugins/XJMusicPlugin/Source/XJMusicPlugin/Private/XjMusicInstanceSubsystem.cpp
+++ b/plugins/unreal/XJGame/Plugins/XJMusicPlugin/Source/XJMusicPlugin/Private/XjMusicInstanceSubsystem.cpp
@@ -5,9 +5,6 @@
 #include <Settings/XJMusicDefaultSettings.h>
 #include <Sound/SoundBase.h>
 #include <Sound/SoundWave.h>
-#include <Engine/StreamableManager.h>
-#include <Engine/AssetManager.h>
-#include <Engine/ObjectLibrary.h>
 #include <Misc/FileHelper.h>
 #include <Runtime/Engine/Public/AudioDevice.h>
 #include <Async/Async.h>
@@ -103,7 +100,7 @@ bool UXjMusicInstanceSubsystem::PlayAudioByName(const FString& Name, const float
 			bool OverrideStartBars = false;
 
 			FQuartzTransportTimeStamp CurrentTimestamp = QuartzClockHandle->GetCurrentTimestamp(GetWorld());
-			float ActualCurrentTime = CurrentTimestamp.Seconds * CurrentTimestamp.BeatFraction;
+			const float ActualCurrentTime = CurrentTimestamp.Seconds * CurrentTimestamp.BeatFraction;
 
 			if (ActualCurrentTime > StartTime)
 			{

--- a/plugins/unreal/XJGame/Plugins/XJMusicPlugin/Source/XJMusicPlugin/Public/Manager/XjManager.h
+++ b/plugins/unreal/XJGame/Plugins/XJMusicPlugin/Source/XJMusicPlugin/Public/Manager/XjManager.h
@@ -3,7 +3,6 @@
 #pragma once
 
 #include "CoreMinimal.h"
-#include "UObject/NoExportTypes.h"
 #include "Types/XjTypes.h"
 #include <Engine/EngineBase.h>
 
@@ -14,7 +13,7 @@ class FXjRunnable : public FRunnable
 
 public:
 
-	FXjRunnable(const FString& XjProjectFolder, const FString& XjProjectFile, UWorld* World);
+	FXjRunnable(const FString& PathToProjectFile, const UWorld* World);
 
 	virtual bool Init() override;
 	virtual uint32 Run() override;
@@ -52,7 +51,7 @@ public:
 
 	void Setup();
 
-	void BeginDestroy() override;
+	virtual void BeginDestroy() override;
 
 	TimeRecord GetAtChainMicros() const
 	{

--- a/plugins/unreal/XJGame/Plugins/XJMusicPlugin/Source/XJMusicPlugin/Public/Manager/XjManager.h
+++ b/plugins/unreal/XJGame/Plugins/XJMusicPlugin/Source/XJMusicPlugin/Public/Manager/XjManager.h
@@ -13,7 +13,7 @@ class FXjRunnable : public FRunnable
 
 public:
 
-	FXjRunnable(const FString& PathToProjectFile, const UWorld* World);
+	FXjRunnable(const FString& PathToProject, const UWorld* World);
 
 	virtual bool Init() override;
 	virtual uint32 Run() override;

--- a/plugins/unreal/XJGame/Plugins/XJMusicPlugin/Source/XJMusicPlugin/Public/Settings/XJMusicDefaultSettings.h
+++ b/plugins/unreal/XJGame/Plugins/XJMusicPlugin/Source/XJMusicPlugin/Public/Settings/XJMusicDefaultSettings.h
@@ -3,7 +3,6 @@
 #pragma once
 
 #include "CoreMinimal.h"
-#include "UObject/NoExportTypes.h"
 #include "XJMusicDefaultSettings.generated.h"
 
 UCLASS(config = "XJMusicConfig")
@@ -16,10 +15,7 @@ public:
 	FString PathToXjMusicWorkstation;
 
 	UPROPERTY(Config, EditAnywhere, Category = Settings)
-	FString XjProjectFolder = "D:/Dev/vgm/";
-
-	UPROPERTY(Config, EditAnywhere, Category = Settings)
-	FString XjProjectFile = "vgm.xj";
+	FString PathToXjProjectFile = "D:/Dev/vgm/vgm.xj";
 
 	UPROPERTY(EditAnywhere, Category = Settings)
 	bool bDevelopmentMode = false;

--- a/plugins/unreal/XJGame/Plugins/XJMusicPlugin/Source/XJMusicPlugin/Public/XJMusicPlugin.h
+++ b/plugins/unreal/XJGame/Plugins/XJMusicPlugin/Source/XJMusicPlugin/Public/XJMusicPlugin.h
@@ -20,11 +20,10 @@ private:
 
 	void RegisterMenus();
 
-	void OnPostWorldInitialization(UWorld* World, const UWorld::InitializationValues IVS);
+	void OnPostWorldInitialization(UWorld* World, const UWorld::InitializationValues Ivs);
 
 	void OnLevelBeginPlay();
 
-private:
 	TSharedPtr<class FUICommandList> PluginCommands;
 
 	UWorld* LastWorld = nullptr;

--- a/plugins/unreal/XJGame/Plugins/XJMusicPlugin/Source/XJMusicPlugin/Public/XjMusicInstanceSubsystem.h
+++ b/plugins/unreal/XJGame/Plugins/XJMusicPlugin/Source/XJMusicPlugin/Public/XjMusicInstanceSubsystem.h
@@ -3,8 +3,8 @@
 #pragma once
 
 #include "CoreMinimal.h"
+#include "Quartz/AudioMixerClockHandle.h"
 #include "Subsystems/GameInstanceSubsystem.h"
-#include "Quartz/QuartzSubsystem.h"
 #include "Widgets/DebugChainView.h"
 
 #include "XjMusicInstanceSubsystem.generated.h"

--- a/plugins/unreal/XJGame/Plugins/XJMusicPlugin/Source/XJMusicPlugin/XJMusicPlugin.Build.cs
+++ b/plugins/unreal/XJGame/Plugins/XJMusicPlugin/Source/XJMusicPlugin/XJMusicPlugin.Build.cs
@@ -15,7 +15,7 @@ public class XJMusicPlugin : ModuleRules
         PublicDependencyModuleNames.AddRange(
 			new string[]
 			{
-				"Core",
+				"Core", "AudioMixer",
 			}
 			);
 			


### PR DESCRIPTION
- XJ music settings, only necessary to provide path to project file (no project folder setting) and we will compute the path to the project folder, see Engine.cpp:165 and then Engine.getPathToBuildDirectory()
- Use clicks the toolbar button in Unreal Engine to open the current Unreal project settings XJ project file in the XJ music workstation - requires #463
- Some C++ nits